### PR TITLE
Temporarily disable golangci-lint because of problems with go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,14 @@ default::
 
 .PHONY: deps
 deps:
-	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+    # TEMPORARILY disable linter because we are unable to install it with the current version of go 1.11.13
+	# We have been unsuccessful tracing what suddenly cause this problem. Skipping linter to unblock us from
+	# delivering code fixes while we find the solution.
+	#
+	# go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 	go get -u github.com/golang/dep/cmd/dep
 	dep ensure -v
+	# go install ./vendor/github.com/golangci/golangci-lint/cmd/golangci-lint
 
 .PHONY: search-collector
 search-collector:
@@ -25,7 +30,8 @@ build-linux:
 
 .PHONY: lint
 lint:
-	golangci-lint run
+	@echo "!!! LINTER temporarily disabled because of issues getting golangci-lint !!!"
+	# golangci-lint run --timeout=2m
 
 .PHONY: test
 test:


### PR DESCRIPTION
Temporary disable the linter to unblock our builds while we resolve the problem.

Issue to re-enable linter: https://github.com/open-cluster-management/backlog/issues/1864