### PR TITLE
Reformat comments in main.go

### DIFF
--- a/codesmells.md
+++ b/codesmells.md
@@ -1,5 +1,0 @@
-Click the link:
-[Major Issues](https://sonarcloud.io/project/issues?id=open-cluster-management_search-collector&resolved=false&severities=MAJOR). 
-[All issues](https://sonarcloud.io/project/issues?id=open-cluster-management_search-collector&resolved=false). 
-
-Click “Why is this an issue?” for more info. 


### PR DESCRIPTION
Fixing comments in main.go to abide by this rule to be fewer than 120 lines. 


All lines must be under 120 columns. Many of our sonar related problems in search-collector will be related to this. The comments are VERY informative and helpful, so we should keep them. Just slighty too lengthy :)



[All Sonarcloud Code Smells for search-collector](https://sonarcloud.io/project/issues?id=open-cluster-management_search-collector&resolved=false).



