### PR TITLE
fix flag in init & migrate to 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 
 language: go
 go:
-  - 1.12.x
+  - 1.13.x
 
 services:
   - docker

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,9 @@
 
 module github.com/open-cluster-management/search-collector
 
-go 1.12
+go 1.13
 
 require (
-	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 	github.com/golang/protobuf v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -1824,7 +1824,7 @@ mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34/go.mod h1:H6SUd1XjIs+qQCyskX
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/letsencrypt v0.0.1/go.mod h1:buyQKZ6IXrRnB7TdkHP0RyEybLx18HHyOSoTyoOLqNY=
 rsc.io/letsencrypt v0.0.3/go.mod h1:buyQKZ6IXrRnB7TdkHP0RyEybLx18HHyOSoTyoOLqNY=
-sigs.k8s.io/application v0.8.3 h1:dL2dYfNFZIdpwLc/pLecfW5fLPtlAvBv5Vwk+4EalV0=
+sigs.k8s.io/application v0.8.3 h1:5UETobiVhxTkKn3pIESImXiMNmSg3VkM5+JvmYGDPko=
 sigs.k8s.io/application v0.8.3/go.mod h1:Mv+ht9RE/QNtITYCzRbt3XTIN6t6so6cInmiyg6wOIg=
 sigs.k8s.io/controller-runtime v0.1.10/go.mod h1:HFAYoOh6XMV+jKF1UjFwrknPbowfyHEHHRdJMf2jMX8=
 sigs.k8s.io/controller-runtime v0.3.0/go.mod h1:Cw6PkEg0Sa7dAYovGT4R0tRkGhHXpYijwNxYhAnAZZk=

--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ irrespective of what has been deposited with the U.S. Copyright Office.
 package main
 
 import (
+	"flag"
+	"fmt"
 	"math"
 	"os"
 	"runtime"
@@ -34,6 +36,15 @@ import (
 )
 
 func main() {
+	// init logs
+	flag.Parse()
+	err := flag.Lookup("logtostderr").Value.Set("true") // Glog is weird in that by default it logs to a file. Change it so that by default it all goes to stderr. (no option for stdout).
+	if err != nil {
+		fmt.Println("Error setting default flag:", err) // Uses fmt.Println in case something is wrong with glog args
+		os.Exit(1)
+		glog.Fatal("Error setting default flag: ", err)
+	}
+	defer glog.Flush() // This should ensure that everything makes it out on to the console if the program crashes.
 
 	// determine number of CPUs available.
 	// We make that many goroutines for transformation and reconciliation,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,16 +64,6 @@ var Cfg = Config{}
 var FilePath = flag.String("c", "./config.json", "Collector configuration file") // -c example.json, config.json is the default
 
 func init() {
-	// parse flags
-	flag.Parse()
-	err := flag.Lookup("logtostderr").Value.Set("true") // Glog is weird in that by default it logs to a file. Change it so that by default it all goes to stderr. (no option for stdout).
-	if err != nil {
-		fmt.Println("Error setting default flag:", err) // Uses fmt.Println in case something is wrong with glog args
-		os.Exit(1)
-		glog.Fatal("Error setting default flag: ", err)
-	}
-	defer glog.Flush() // This should ensure that everything makes it out on to the console if the program crashes.
-
 	// Load default config from ./config.json.
 	// These can be overridden in the next step if environment variables are set.
 	if _, err := os.Stat(filepath.Join(".", "config.json")); !os.IsNotExist(err) {


### PR DESCRIPTION
Updates:
- moved glog flag from init() to main()
- updated to go 1.13

Tests:
- [x] apply image in an imported cluster, and output log as before