### PR TITLE
Set GOGC=50 on docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN microdnf update &&\
 
 ENV VCS_REF="$VCS_REF" \
     USER_UID=1001 \
-    GOGC=25
+    GOGC=50
 
 ADD output/search-collector /bin
 


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/3910

Apply GOGC flag on docker container to increase garbage collection.

@mqhackett Can you help to duplicate this change downstream?

![image](https://user-images.githubusercontent.com/4671325/92135307-9a8ef380-edd8-11ea-858d-b07393e0856c.png)

![image](https://user-images.githubusercontent.com/4671325/92137504-328ddc80-eddb-11ea-9172-a24b80b03fd8.png)
