### PR TITLE
Revert "Update copyrights (#97)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 # Copyright (c) 2020 Red Hat, Inc.
-# Copyright Contributors to the Open Cluster Management project
 
 os:
   - linux

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 # Copyright (c) 2020 Red Hat, Inc.
-# Copyright Contributors to the Open Cluster Management project
 
 include build/Configfile
 BINDIR ?= output
@@ -46,6 +45,10 @@ test:
 .PHONY: coverage
 coverage:
 	go tool cover -html=cover.out -o=cover.html
+
+.PHONY: copyright-check
+copyright-check:
+	./build/copyright-check.sh
 
 .PHONY: clean
 clean::

--- a/build/Configfile
+++ b/build/Configfile
@@ -1,5 +1,3 @@
-# Copyright Contributors to the Open Cluster Management project
-
 ifdef GIT
 IMAGE_VERSION :=$(shell git rev-parse --short HEAD)
 VCS_URL ?=$(shell git config --get remote.origin.url)

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# Copyright Contributors to the Open Cluster Management project
-
 echo " > Running build.sh"
 set -e
 

--- a/build/copyright-check.sh
+++ b/build/copyright-check.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+###############################################################################
+# (c) Copyright IBM Corporation 2019, 2020. All Rights Reserved.
+# Note to U.S. Government Users Restricted Rights:
+# U.S. Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule
+# Contract with IBM Corp.
+# Licensed Materials - Property of IBM
+# Copyright (c) 2020 Red Hat, Inc.
+###############################################################################
+
+#Project start year
+origin_year=2016
+#Back up year if system time is null or incorrect
+back_up_year=2019
+#Currrent year
+current_year=$(date +"%Y")
+
+TRAVIS_BRANCH=$1
+
+ADDED_SINCE_1_MAR_2020=$(git log --name-status --pretty=oneline --since "1 Mar 2020" | egrep "^A\t" | awk '{print $2}' | sort | uniq |  grep -v -f <(sed 's/\([.|]\)/\\\1/g; s/\?/./g ; s/\*/.*/g'))
+MODIFIED_SINCE_1_MAR_2020=$(diff --new-line-format="" --unchanged-line-format="" <(git log --name-status --pretty=oneline --since "1 Mar 2020" | egrep "^A\t|^M\t" | awk '{print $2}' | sort | uniq | grep -v -f <(sed 's/\([.|]\)/\\\1/g; s/\?/./g ; s/\*/.*/g' )) <(git log --name-status --pretty=oneline --since "1 Mar 2020" | egrep "^A\t" | awk '{print $2}' | sort | uniq | grep -v -f <(sed 's/\([.|]\)/\\\1/g; s/\?/./g ; s/\*/.*/g')))
+OLDER_GIT_FILES=$(git log --name-status --pretty=oneline | egrep "^A\t|^M\t" | awk '{print $2}' | sort | uniq |  grep -v -f <(sed 's/\([.|]\)/\\\1/g; s/\?/./g ; s/\*/.*/g'))
+
+if [[ "x${TRAVIS_BRANCH}" != "x" ]]; then
+  FILES_TO_SCAN=$(git diff --name-only --diff-filter=AM ${TRAVIS_BRANCH}...HEAD | grep -v -f <(sed 's/\([.|]\)/\\\1/g; s/\?/./g ; s/\*/.*/g'))
+else
+  FILES_TO_SCAN=$(find . -type f | grep -Ev '(\.git)' | grep -v -f <(sed 's/\([.|]\)/\\\1/g; s/\?/./g ; s/\*/.*/g'))
+fi
+
+if [ -z "$current_year" ] || [ $current_year -lt $origin_year ]; then
+  echo "Can't get correct system time\n  >>Use back_up_year=$back_up_year as current_year to check copyright in the file $f\n"
+  current_year=$back_up_year
+fi
+
+lic_ibm_identifier=" (c) Copyright IBM Corporation"
+lic_redhat_identifier=" Copyright (c) ${current_year} Red Hat, Inc."
+
+lic_year=()
+#All possible combination within [origin_year, current_year] range is valid format
+#seq isn't recommanded after bash version 3.0
+for ((start_year=origin_year;start_year<=current_year;start_year++)); 
+do
+  lic_year+=(" (c) Copyright IBM Corporation ${start_year}. All Rights Reserved.")
+  for ((end_year=start_year+1;end_year<=current_year;end_year++)); 
+  do
+    lic_year+=(" (c) Copyright IBM Corporation ${start_year}, ${end_year}. All Rights Reserved.")
+  done
+done
+lic_year_size=${#lic_year[@]}
+
+#lic_rest to scan for rest copyright format's correctness
+lic_rest=()
+lic_rest+=(" Licensed Materials - Property of IBM")
+lic_rest+=(" Note to U.S. Government Users Restricted Rights:")
+lic_rest+=(" Use, duplication or disclosure restricted by GSA ADP Schedule")
+lic_rest+=(" Contract with IBM Corp.")
+lic_rest_size=${#lic_rest[@]}
+
+#Used to signal an exit
+ERROR=0
+RETURNCODE=0
+
+echo "##### Copyright check #####"
+#Loop through all files. Ignore .FILENAME types
+#for f in `find .. -type f ! -path "../.eslintrc.js" ! -path "../build-harness/*" ! -path "../auth-setup/*" ! -path "../sslcert/*" ! -path "../node_modules/*" ! -path "../coverage/*" ! -path "../test-output/*" ! -path "../build/*" ! -path "../nls/*" ! -path "../public/*"`; do
+for f in $FILES_TO_SCAN; do
+  if [ ! -f "$f" ]; then
+   continue
+  fi
+
+  # Flags that indicate the licenses to check for
+  must_have_redhat_license=false
+  must_have_ibm_license=false
+  flag_redhat_license=false
+  flag_ibm_license=false
+
+  FILETYPE=$(basename ${f##*.})
+  case "${FILETYPE}" in
+  	js | go | scss | properties | java | rb | sh )
+  		COMMENT_PREFIX=""
+  		;;
+  	*)
+      #printf " Extension $FILETYPE not considered !!!\n"
+      continue
+  esac
+
+  #Read the first 15 lines, most Copyright headers use the first 10 lines.
+  header=`head -15 $f`
+
+  # Strip directory prefix, if any
+  if [[ $f == "./"* ]]; then
+    f=${f:2}
+  fi
+
+  printf " ========>>>>>>   Scanning $f . . .\n"
+  if [[ "${ADDED_SINCE_1_MAR_2020}" == *"$f"* ]]; then
+    printf " ---> Added since 01/03/2020\n"
+    must_have_redhat_license=true
+    flag_ibm_license=true
+  elif [[ "${MODIFIED_SINCE_1_MAR_2020}" == *"$f"* ]]; then
+    printf " ---> Modified since 01/03/2020\n"
+    must_have_redhat_license=true
+    must_have_ibm_license=true
+  elif [[ "${OLDER_GIT_FILES}" == *"$f"* ]]; then
+    printf " ---> File older than 01/03/2020\n"
+    must_have_ibm_license=true
+    flag_redhat_license=true
+  else
+    # Default case, could be new file not yet in git(?) - only expect Red Hat license
+    must_have_redhat_license=true
+  fi
+
+  if [[ "${must_have_redhat_license}" == "true" ]] && [[ "$header" != *"${lic_redhat_identifier}"* ]]; then
+    printf " Missing copyright\n >> Could not find [${lic_redhat_identifier}] in the file.\n"
+    ERROR=1
+  fi
+
+  if [[ "${flag_redhat_license}" == "true" ]] && [[ "$header" == *"${lic_redhat_identifier}"* ]]; then 
+    printf " Warning: Older file, may not include Red Hat license.\n"
+  fi
+
+  if [[ "${flag_ibm_license}" == "true" ]] && [[ "$header" == *"${lic_ibm_identifier}"* ]]; then 
+    printf " Warning: newer file, may not contain IBM license.\n"
+  fi
+
+  if [[ "${must_have_ibm_license}" == "true" ]]; then 
+    # Verify IBM copyright is present
+    #Check for year copyright single line
+    year_line_count=0
+    for ((i=0;i<${lic_year_size};i++));
+    do
+      #Validate year formart within [origin_year, current_year] range
+      if [[ "$header" == *"${lic_year[$i]}"* ]]; then
+        year_line_count=$((year_line_count + 1))
+      fi
+    done
+
+    #Must find and only find one line valid year, otherwise invalid copyright formart
+    if [[ $year_line_count != 1 ]]; then
+      printf "Missing copyright\n  >>Could not find correct copyright year in the file $f\n"
+      ERROR=1
+      #break 
+    fi
+
+    #Check for rest copyright lines
+    for ((i=0;i<${lic_rest_size};i++));
+    do
+      #Validate the copyright line being checked is present
+      if [[ "$header" != *"${lic_rest[$i]}"* ]]; then
+        printf "Missing copyright\n  >>Could not find [${lic_rest[$i]}] in the file $f\n"
+        ERROR=1
+        #break 2
+      fi
+    done
+  fi # end must_have_ibm_license
+
+  #Add a status message of OK, if all copyright lines are found
+  if [[ "$ERROR" == 0 ]]; then
+    printf "OK\n"
+  else
+    RETURNCODE=$ERROR
+    ERROR=0 # Reset error
+  fi
+done
+
+echo "##### Copyright check ##### ReturnCode: ${RETURNCODE}"
+exit $RETURNCODE

--- a/build/deploy-to-cluster.sh
+++ b/build/deploy-to-cluster.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# Copyright Contributors to the Open Cluster Management project
-
 echo " > Running deploy-to-cluster.sh"
 set -e
 exit 0

--- a/build/install-dependencies.sh
+++ b/build/install-dependencies.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# Copyright Contributors to the Open Cluster Management project
-
 echo " > Running install-dependencies.sh"
 set -e
 make deps

--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# Copyright Contributors to the Open Cluster Management project
-
 echo " > Running run-e2e-test.sh"
 set -e
 sh tests/e2e/runTests.sh $1

--- a/build/run-unit-tests.sh
+++ b/build/run-unit-tests.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
-# Copyright Contributors to the Open Cluster Management project
-
 echo " > Running run-unit-tests.sh"
 set -e
 
+make copyright-check
 make deps
 make lint
 make test

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,4 @@
 // Copyright (c) 2020 Red Hat, Inc.
-// Copyright Contributors to the Open Cluster Management project
 
 module github.com/open-cluster-management/search-collector
 

--- a/main.go
+++ b/main.go
@@ -1,8 +1,12 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package main
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020, 2021 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020, 2021 Red Hat, Inc.
+*/
 
 package config
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,7 +1,4 @@
-/*
- * Copyright (c) 2021 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+// Copyright (c) 2021 Red Hat, Inc.
 
 package config
 

--- a/pkg/config/kubeClient.go
+++ b/pkg/config/kubeClient.go
@@ -1,7 +1,4 @@
-/*
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+// Copyright (c) 2020 Red Hat, Inc.
 
 package config
 

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -1,7 +1,4 @@
-/*
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+// Copyright (c) 2020 Red Hat, Inc.
 
 package informer
 

--- a/pkg/informer/informer_test.go
+++ b/pkg/informer/informer_test.go
@@ -1,7 +1,4 @@
-/*
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+// Copyright (c) 2020 Red Hat, Inc.
 
 package informer
 

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -1,8 +1,12 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package reconciler
 

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package reconciler
 

--- a/pkg/send/httpsClient.go
+++ b/pkg/send/httpsClient.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+*/
+// Copyright (c) 2020 Red Hat, Inc.
 
 package send
 

--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package send
 

--- a/pkg/send/sender_test.go
+++ b/pkg/send/sender_test.go
@@ -1,8 +1,10 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2021 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+*/
 
 package send
 

--- a/pkg/transforms/appdeployable.go
+++ b/pkg/transforms/appdeployable.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/appdeployable_test.go
+++ b/pkg/transforms/appdeployable_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/apphelmcr.go
+++ b/pkg/transforms/apphelmcr.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/apphelmcr_test.go
+++ b/pkg/transforms/apphelmcr_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/application.go
+++ b/pkg/transforms/application.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/application_test.go
+++ b/pkg/transforms/application_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/channel.go
+++ b/pkg/transforms/channel.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/channel_test.go
+++ b/pkg/transforms/channel_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/common_test.go
+++ b/pkg/transforms/common_test.go
@@ -1,8 +1,10 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+*/
 
 package transforms
 

--- a/pkg/transforms/cronjob.go
+++ b/pkg/transforms/cronjob.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/cronjob_test.go
+++ b/pkg/transforms/cronjob_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/daemonset.go
+++ b/pkg/transforms/daemonset.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/daemonset_test.go
+++ b/pkg/transforms/daemonset_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/deployment.go
+++ b/pkg/transforms/deployment.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/deployment_test.go
+++ b/pkg/transforms/deployment_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/deploymentconfig.go
+++ b/pkg/transforms/deploymentconfig.go
@@ -1,7 +1,6 @@
 /*
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/deploymentconfig_test.go
+++ b/pkg/transforms/deploymentconfig_test.go
@@ -1,7 +1,6 @@
 /*
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/genericresource.go
+++ b/pkg/transforms/genericresource.go
@@ -1,7 +1,4 @@
-/*
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+// Copyright (c) 2020 Red Hat, Inc.
 
 package transforms
 

--- a/pkg/transforms/helmrelease.go
+++ b/pkg/transforms/helmrelease.go
@@ -1,8 +1,10 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2021 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+*/
 
 package transforms
 

--- a/pkg/transforms/helmrelease_test.go
+++ b/pkg/transforms/helmrelease_test.go
@@ -1,8 +1,10 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2021 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+*/
 
 package transforms
 

--- a/pkg/transforms/job_test.go
+++ b/pkg/transforms/job_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/namespace.go
+++ b/pkg/transforms/namespace.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/namespace_test.go
+++ b/pkg/transforms/namespace_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/node.go
+++ b/pkg/transforms/node.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020, 2021 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/node_test.go
+++ b/pkg/transforms/node_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/persistentvolume.go
+++ b/pkg/transforms/persistentvolume.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/persistentvolume_test.go
+++ b/pkg/transforms/persistentvolume_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/persistentvolumeclaim.go
+++ b/pkg/transforms/persistentvolumeclaim.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/persistentvolumeclaim_test.go
+++ b/pkg/transforms/persistentvolumeclaim_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/placementbinding.go
+++ b/pkg/transforms/placementbinding.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/placementbinding_test.go
+++ b/pkg/transforms/placementbinding_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/placementpolicy.go
+++ b/pkg/transforms/placementpolicy.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/placementpolicy_test.go
+++ b/pkg/transforms/placementpolicy_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/placementrule.go
+++ b/pkg/transforms/placementrule.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/placementrule_test.go
+++ b/pkg/transforms/placementrule_test.go
@@ -1,8 +1,10 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+*/
 
 package transforms
 

--- a/pkg/transforms/pod.go
+++ b/pkg/transforms/pod.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/pod_test.go
+++ b/pkg/transforms/pod_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/policy.go
+++ b/pkg/transforms/policy.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/policy_test.go
+++ b/pkg/transforms/policy_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/replicaset.go
+++ b/pkg/transforms/replicaset.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/replicaset_test.go
+++ b/pkg/transforms/replicaset_test.go
@@ -1,8 +1,10 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2021 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+*/
 
 package transforms
 

--- a/pkg/transforms/service.go
+++ b/pkg/transforms/service.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/service_test.go
+++ b/pkg/transforms/service_test.go
@@ -1,9 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
-
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 package transforms
 
 import (

--- a/pkg/transforms/statefulset.go
+++ b/pkg/transforms/statefulset.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/statefulset_test.go
+++ b/pkg/transforms/statefulset_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/subscription.go
+++ b/pkg/transforms/subscription.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/subscription_test.go
+++ b/pkg/transforms/subscription_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/testutils.go
+++ b/pkg/transforms/testutils.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+*/
+// Copyright (c) 2020 Red Hat, Inc.
 
 // Contains utils for use in testing.
 package transforms

--- a/pkg/transforms/transformer.go
+++ b/pkg/transforms/transformer.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/pkg/transforms/transformer_test.go
+++ b/pkg/transforms/transformer_test.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package transforms
 

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ The data model is documented at ./pkg/transforms/README.md
 ## Usage and Configuration
 
 ### Running Locally
-> **Pre-requisite:** Go v1.15
+> **Pre-requisite:** Go v1.13
 1. Fetch Dependencies: `make deps`
     > **TIP 1:** You may need to install mercurial. `brew install mercurial`
     >

--- a/tests/e2e/resourceBudgetTest.sh
+++ b/tests/e2e/resourceBudgetTest.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # Copyright (c) 2020 Red Hat, Inc.
-# Copyright Contributors to the Open Cluster Management project
 
 echo "=== TEST: Memory and CPU budget ===\n"
 

--- a/tests/e2e/runTests.sh
+++ b/tests/e2e/runTests.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
 # Copyright (c) 2020 Red Hat, Inc.
-# Copyright Contributors to the Open Cluster Management project
 
 sh tests/e2e/resourceBudgetTest.sh $1


### PR DESCRIPTION
This reverts commit 9e9869aa9f832a16161c4e08aabec13b5d56347a.

**Related Issue:**  open-cluster-management/backlog#<ISSUE_NUMBER>

### Description of changes
- The guidance is to keep the existing copyright language and add the new copyrights below. 

