### PR TITLE
Filter out grc sourced vioilations from PolicyReport results

### DIFF
--- a/test-data/policyreport.json
+++ b/test-data/policyreport.json
@@ -1,41 +1,43 @@
 {
-    "kind": "PolicyReport",
-    "apiVersion": "wgpolicyk8s.io/v1alpha1",
-    "metadata": {
-        "name": "report.risk.1",
-        "namespace": "test-cluster"
-    },
-    "results": [
-        {
-            "category": "category,category1,category2",
-            "properties": {
-                "created_at": "2021-03-02T21:26:04Z",
-                "details": "policyreport testing risk 1 details",
-                "reason": "policyreport testing risk 1 reason",
-                "resolution": "policyreport testing risk 1 resolution",
-                "total_risk": "1"
-            },
-            "message": "policyreport testing risk 1",
-            "policy": "policyreport testing risk 1 policy",
-            "result": "error"
-        },
-        {
-            "category": "category,category3,category4",
-            "properties": {
-                "created_at": "2021-03-02T21:26:04Z",
-                "details": "policyreport testing risk 2 details",
-                "reason": "policyreport testing risk 2 reason",
-                "resolution": "policyreport testing risk 2 resolution",
-                "total_risk": "2"
-            },
-            "message": "policyreport testing risk 2",
-            "policy": "policyreport testing risk 2 policy",
-            "result": "error"
-        }
-    ],
-    "scope": {
-        "kind": "cluster",
-        "name": "test-cluster",
-        "namespace": "test-cluster"
-    }
+	"kind": "PolicyReport",
+	"apiVersion": "wgpolicyk8s.io/v1alpha1",
+	"metadata": {
+		"name": "report.risk.1",
+		"namespace": "test-cluster"
+	},
+	"results": [
+		{
+			"category": "category,category1,category2",
+			"properties": {
+				"created_at": "2021-03-02T21:26:04Z",
+				"details": "policyreport testing risk 1 details",
+				"reason": "policyreport testing risk 1 reason",
+				"resolution": "policyreport testing risk 1 resolution",
+				"total_risk": "1"
+			},
+			"message": "policyreport testing risk 1",
+			"policy": "policyreport testing risk 1 policy",
+			"result": "error",
+			"source": "insights"
+		},
+		{
+			"category": "category,category3,category4",
+			"properties": {
+				"created_at": "2021-03-02T21:26:04Z",
+				"details": "policyreport testing risk 2 details",
+				"reason": "policyreport testing risk 2 reason",
+				"resolution": "policyreport testing risk 2 resolution",
+				"total_risk": "2"
+			},
+			"message": "policyreport testing risk 2",
+			"policy": "policyreport testing risk 2 policy",
+			"result": "error",
+			"source": "insights"
+		}
+	],
+	"scope": {
+		"kind": "cluster",
+		"name": "test-cluster",
+		"namespace": "test-cluster"
+	}
 }


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

**Related Issue:** open-cluster-management/backlog#19172

### Description of changes
- Policy violation details are displayed elsewhere in the UI, displaying them in the PR will result in double counts on pages. So this PR filters the grc sourced violations from the PolicyReport node data.

