### PR TITLE
add hosting application set property in support of argocd integration…

### DIFF
--- a/pkg/transforms/argoapplication.go
+++ b/pkg/transforms/argoapplication.go
@@ -88,6 +88,13 @@ func ArgoApplicationResourceBuilder(a *ArgoApplication) *ArgoApplicationResource
 
 	node.Properties["applicationSet"] = applicationSet
 
+	// add its hosting applicationSet namespaced name, if the argocd app is propogated by ACM argocd pull integration controller
+	if a.Annotations != nil {
+		if a.Annotations["apps.open-cluster-management.io/hosting-applicationset"] != "" {
+			node.Properties["_hostingResource"] = "ApplicationSet/" + a.Annotations["apps.open-cluster-management.io/hosting-applicationset"]
+		}
+	}
+
 	// Destination properties
 	node.Properties["destinationName"] = a.Spec.Destination.Name
 	node.Properties["destinationNamespace"] = a.Spec.Destination.Namespace

--- a/pkg/transforms/argoapplication_test.go
+++ b/pkg/transforms/argoapplication_test.go
@@ -16,6 +16,7 @@ func TestTransformArgoApplication(t *testing.T) {
 	// Test only the fields that exist in application - the common test will test the other bits
 	AssertEqual("kind", node.Properties["kind"], "Application", t)
 	AssertEqual("applicationSet", node.Properties["applicationSet"], "helloworld-set", t)
+	AssertEqual("hostingResource", node.Properties["_hostingResource"], "ApplicationSet/openshift-gitops/bgdk-app-set", t)
 	AssertEqual("destinationName", node.Properties["destinationName"], "local-cluster", t)
 	AssertEqual("destinationNamespace", node.Properties["destinationNamespace"], "argo-helloworld", t)
 	AssertEqual("destinationServer", node.Properties["destinationServer"], "https://kubernetes.default.svc", t)

--- a/test-data/argoapplication.json
+++ b/test-data/argoapplication.json
@@ -2,6 +2,9 @@
   "apiVersion": "argoproj.io/v1alpha1",
   "kind": "Application",
   "metadata": {
+      "annotations": {
+        "apps.open-cluster-management.io/hosting-applicationset": "openshift-gitops/bgdk-app-set"
+      },
       "creationTimestamp": "2021-02-10T02:15:57Z",
       "name": "helloworld",
       "namespace": "argocd",
@@ -85,6 +88,5 @@
             "message": "invalid spec in the argocd application"
         }
     ]
-
   }
 }


### PR DESCRIPTION
… with pull model

Signed-off-by: Xiangjing Li <xiangli@redhat.com>

### Description of changes

1. Add a new property `hostingApplicationSet` to indicate the hosting applicationset if the argocd application is deployed by pull model. 
The `hostingApplicationSet` info is from the hosting-applicationset annotation in the argocd application CR on the managed cluster 

2. While the existing `applicationSet` is to show the its parent applicationset if the argocd app is deployed by push model
The applicationSet info is from the owner reference in the argocd application CR on the hub cluster.

To-Do:
We will work with app UI in 2.8 to see if we can use one applicationSet field to show the parent argocd applicationset, regardless of the argo application being deployed by pull model or push model.
