### PR TITLE
don't bundle operationState message if its phase is succeeded

### DIFF
--- a/pkg/transforms/argoapplication.go
+++ b/pkg/transforms/argoapplication.go
@@ -63,6 +63,8 @@ type ApplicationCondition struct {
 
 // OperationState contains information about state of a running operation
 type OperationState struct {
+	// Phase is the current phase of the operation
+	Phase string `json:"phase" protobuf:"bytes,2,opt,name=phase"`
 	// Message holds any pertinent messages when attempting to perform operation (typically errors).
 	Message string `json:"message,omitempty" protobuf:"bytes,3,opt,name=message"`
 }
@@ -131,7 +133,7 @@ func ArgoApplicationResourceBuilder(a *ArgoApplication) *ArgoApplicationResource
 
 	// if there is operationState.message, append it to the error condition property
 	if a.Status.Health.Status != "Healthy" || a.Status.Sync.Status != "Synced" {
-		if a.Status.OperationState != nil && a.Status.OperationState.Message != "" {
+		if a.Status.OperationState != nil && a.Status.OperationState.Message != "" && a.Status.OperationState.Phase != "Succeeded" {
 			truncatedMessage := TruncateText(a.Status.OperationState.Message, 512)
 			if truncatedMessage > "" {
 				node.Properties["_condition"+"OperationError"] = truncatedMessage

--- a/test-data/argoapplication.json
+++ b/test-data/argoapplication.json
@@ -89,8 +89,8 @@
         }
     ],
     "operationState": {
+        "phase": "Failed",
         "message": "one or more objects failed to apply, reason: deployments.apps is forbidden: User 'system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller' cannot create resource 'deployments' in API group 'apps' in the namespace 'helm-nginx',serviceaccounts is forbidden: User 'system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller' cannot create resource 'serviceaccounts' in API group '' in the namespace 'helm-nginx',services is forbidden: User 'system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller' cannot create resource 'services' in API group '' in the namespace 'helm-nginx'. Retrying attempt #2 at 2:35AM."
     }
-
   }
 }


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

### Description of changes

We found that one argo application status could be like this
- its health status is not healthy 
- its sync status is  not synced
- while its operationState phase is succeeded 

In this case, we should not bundle the operationState message as it is not error message