### PR TITLE
Refactor: simplify main by moving logic to start informers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,6 @@
 include build/Configfile
 BINDIR ?= output
 
-USE_VENDORIZED_BUILD_HARNESS ?=
-
-ifndef USE_VENDORIZED_BUILD_HARNESS
--include $(shell curl -s -H 'Authorization: token ${GITHUB_TOKEN}' -H 'Accept: application/vnd.github.v4.raw' -L https://api.github.com/repos/stolostron/build-harness-extensions/contents/templates/Makefile.build-harness-bootstrap -o .build-harness-bootstrap; echo .build-harness-bootstrap)
-else
--include vbh/.build-harness-vendorized
-endif
-
-default::
-	@echo "Build Harness Bootstrapped"
 
 .PHONY: deps
 deps:

--- a/main.go
+++ b/main.go
@@ -76,6 +76,9 @@ func main() {
 	// Start a routine to keep our informers up to date.
 	go informer.RunInformers(informersInitialized, upsertTransformer, reconciler)
 
+	// Wait here until informers have collected the full state of the cluster.
+	// The initial payload must have the complete state to avoid unecessary deletion
+	// and recreate of existing rows in the database during the resync.
 	glog.Info("Waiting for informers to load initial state.")
 	<-informersInitialized
 

--- a/main.go
+++ b/main.go
@@ -1,12 +1,3 @@
-/*
-IBM Confidential
-OCO Source Materials
-(C) Copyright IBM Corporation 2019 All Rights Reserved
-The source code for this program is not published or otherwise divested of its trade secrets,
-irrespective of what has been deposited with the U.S. Copyright Office.
-
-Copyright (c) 2020 Red Hat, Inc.
-*/
 // Copyright Contributors to the Open Cluster Management project
 
 package main
@@ -16,19 +7,16 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/stolostron/search-collector/pkg/config"
-	inform "github.com/stolostron/search-collector/pkg/informer"
+	"github.com/stolostron/search-collector/pkg/informer"
 	lease "github.com/stolostron/search-collector/pkg/lease"
 	rec "github.com/stolostron/search-collector/pkg/reconciler"
 	tr "github.com/stolostron/search-collector/pkg/transforms"
 
 	"github.com/golang/glog"
 	"github.com/stolostron/search-collector/pkg/send"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -83,107 +71,13 @@ func main() {
 	// Create Sender, attached to transformer
 	sender := send.NewSender(reconciler, config.Cfg.AggregatorURL, config.Cfg.ClusterName)
 
-	// Get kubernetes client for discovering resource types
-	discoveryClient := config.GetDiscoveryClient()
-
-	// These functions return handler functions, which are then used in creation of the informers.
-	createInformerAddHandler := func(resourceName string) func(interface{}) {
-		return func(obj interface{}) {
-			resource := obj.(*unstructured.Unstructured)
-			upsert := tr.Event{
-				Time:           time.Now().Unix(),
-				Operation:      tr.Create,
-				Resource:       resource,
-				ResourceString: resourceName,
-			}
-			upsertTransformer.Input <- &upsert // Send resource into the transformer input channel
-		}
-	}
-
-	createInformerUpdateHandler := func(resourceName string) func(interface{}, interface{}) {
-		return func(oldObj, newObj interface{}) {
-			resource := newObj.(*unstructured.Unstructured)
-			upsert := tr.Event{
-				Time:           time.Now().Unix(),
-				Operation:      tr.Update,
-				Resource:       resource,
-				ResourceString: resourceName,
-			}
-			upsertTransformer.Input <- &upsert // Send resource into the transformer input channel
-		}
-	}
-
-	informerDeleteHandler := func(obj interface{}) {
-		resource := obj.(*unstructured.Unstructured)
-		// We don't actually have anything to transform in the case of a deletion, so we manually construct the NodeEvent
-		ne := tr.NodeEvent{
-			Time:      time.Now().Unix(),
-			Operation: tr.Delete,
-			Node: tr.Node{
-				UID: strings.Join([]string{config.Cfg.ClusterName, string(resource.GetUID())}, "/"),
-			},
-		}
-		reconciler.Input <- ne
-	}
-
-	informersStarted := false
+	informersInitialized := make(chan interface{})
 
 	// Start a routine to keep our informers up to date.
-	go func() {
-		// We keep each of the informer's stopper channel in a map, so we can stop them if the resource is no longer valid.
-		stoppers := make(map[schema.GroupVersionResource]chan struct{})
-		for {
-			gvrList, err := inform.SupportedResources(discoveryClient)
-			if err != nil {
-				glog.Error("Failed to get complete list of supported resources: ", err)
-			}
+	go informer.RunInformers(informersInitialized, upsertTransformer, reconciler)
 
-			// Sometimes a partial list will be returned even if there is an error.
-			// This could happen during install when a CRD hasn't fully initialized.
-			if gvrList != nil {
-				// Loop through the previous list of resources. If we find the entry in the new list we delete it so
-				// that we don't end up with 2 informers. If we don't find it, we stop the informer that's currently
-				// running because the resource no longer exists (or no longer supports watch).
-				for gvr, stopper := range stoppers {
-					// If this still exists in the new list, delete it from there as we don't want to recreate an informer
-					if _, ok := gvrList[gvr]; ok {
-						delete(gvrList, gvr)
-						continue
-					} else { // if it's in the old and NOT in the new, stop the informer
-						glog.V(2).Infof("Resource %s no longer exists or no longer supports watch, stopping its informer\n", gvr.String())
-						close(stopper)
-						delete(stoppers, gvr)
-					}
-				}
-				// Now, loop through the new list, which after the above deletions, contains only stuff that needs to
-				// have a new informer created for it.
-				for gvr := range gvrList {
-					glog.V(2).Infof("Found new resource %s, creating informer\n", gvr.String())
-					// Using our custom informer.
-					informer, _ := inform.InformerForResource(gvr)
-
-					// Set up handler to pass this informer's resources into transformer
-					informer.AddFunc = createInformerAddHandler(gvr.Resource)
-					informer.UpdateFunc = createInformerUpdateHandler(gvr.Resource)
-					informer.DeleteFunc = informerDeleteHandler
-
-					stopper := make(chan struct{})
-					stoppers[gvr] = stopper
-					go informer.Run(stopper)
-					informer.WaitUntilInitialized(time.Duration(10) * time.Second) // Times out after 10 seconds.
-				}
-				glog.V(2).Info("Total informers running: ", len(stoppers))
-				informersStarted = true
-			}
-
-			time.Sleep(time.Duration(config.Cfg.RediscoverRateMS) * time.Millisecond)
-		}
-	}()
-
-	glog.Info("Waiting for informers to load initial state...")
-	for !informersStarted {
-		time.Sleep(time.Duration(100) * time.Millisecond)
-	}
+	glog.Info("Waiting for informers to load initial state.")
+	<-informersInitialized
 
 	glog.Info("Starting the sender.")
 	sender.StartSendLoop()

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -106,7 +106,7 @@ func (inform *GenericInformer) listAndResync() error {
 	newResourceIndex := make(map[string]string)
 
 	// We need this limit to avoid a memory spike. Smaller chunks allows us to release memory faster, however
-	// it generates more requests to he kube api server.
+	// it generates more requests to the kube api server.
 	opts := metav1.ListOptions{Limit: 250}
 	for {
 		resources, listError := inform.client.Resource(inform.gvr).List(context.TODO(), opts)

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -105,7 +105,8 @@ func (inform *GenericInformer) listAndResync() error {
 	// Keep track of new resources added to consolidate against the previous state.
 	newResourceIndex := make(map[string]string)
 
-	// List resources.
+	// We need this limit to avoid a memory spike. Smaller chunks allows us to release memory faster, however
+	// it generates more requests to he kube api server.
 	opts := metav1.ListOptions{Limit: 250}
 	for {
 		resources, listError := inform.client.Resource(inform.gvr).List(context.TODO(), opts)
@@ -141,7 +142,7 @@ func (inform *GenericInformer) listAndResync() error {
 			glog.V(3).Infof("Resource does not exist. Deleting resource: %s with UID: %s", inform.gvr.Resource, key)
 			obj := newUnstructured(inform.gvr.Resource, key)
 			inform.DeleteFunc(obj)
-			delete(inform.resourceIndex, key) // Thread safe?
+			delete(inform.resourceIndex, key)
 		}
 	}
 	return nil

--- a/pkg/informer/runInformers.go
+++ b/pkg/informer/runInformers.go
@@ -1,0 +1,114 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package informer
+
+import (
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/stolostron/search-collector/pkg/config"
+	rec "github.com/stolostron/search-collector/pkg/reconciler"
+	tr "github.com/stolostron/search-collector/pkg/transforms"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Start and manages informers for resources in the cluster.
+func RunInformers(initialized chan interface{}, upsertTransformer tr.Transformer, reconciler *rec.Reconciler) {
+
+	// These functions return handler functions, which are then used in creation of the informers.
+	createInformerAddHandler := func(resourceName string) func(interface{}) {
+		return func(obj interface{}) {
+			resource := obj.(*unstructured.Unstructured)
+			upsert := tr.Event{
+				Time:           time.Now().Unix(),
+				Operation:      tr.Create,
+				Resource:       resource,
+				ResourceString: resourceName,
+			}
+			upsertTransformer.Input <- &upsert // Send resource into the transformer input channel
+		}
+	}
+
+	createInformerUpdateHandler := func(resourceName string) func(interface{}, interface{}) {
+		return func(oldObj, newObj interface{}) {
+			resource := newObj.(*unstructured.Unstructured)
+			upsert := tr.Event{
+				Time:           time.Now().Unix(),
+				Operation:      tr.Update,
+				Resource:       resource,
+				ResourceString: resourceName,
+			}
+			upsertTransformer.Input <- &upsert // Send resource into the transformer input channel
+		}
+	}
+
+	informerDeleteHandler := func(obj interface{}) {
+		resource := obj.(*unstructured.Unstructured)
+		// We don't actually have anything to transform in the case of a deletion, so we manually construct the NodeEvent
+		ne := tr.NodeEvent{
+			Time:      time.Now().Unix(),
+			Operation: tr.Delete,
+			Node: tr.Node{
+				UID: strings.Join([]string{config.Cfg.ClusterName, string(resource.GetUID())}, "/"),
+			},
+		}
+		reconciler.Input <- ne
+	}
+
+	// Get kubernetes client for discovering resource types
+	discoveryClient := config.GetDiscoveryClient()
+
+	// We keep each of the informer's stopper channel in a map, so we can stop them if the resource is no longer valid.
+	stoppers := make(map[schema.GroupVersionResource]chan struct{})
+	for {
+		gvrList, err := SupportedResources(discoveryClient)
+		if err != nil {
+			glog.Error("Failed to get complete list of supported resources: ", err)
+		}
+
+		// Sometimes a partial list will be returned even if there is an error.
+		// This could happen during install when a CRD hasn't fully initialized.
+		if gvrList != nil {
+			// Loop through the previous list of resources. If we find the entry in the new list we delete it so
+			// that we don't end up with 2 informers. If we don't find it, we stop the informer that's currently
+			// running because the resource no longer exists (or no longer supports watch).
+			for gvr, stopper := range stoppers {
+				// If this still exists in the new list, delete it from there as we don't want to recreate an informer
+				if _, ok := gvrList[gvr]; ok {
+					delete(gvrList, gvr)
+					continue
+				} else { // if it's in the old and NOT in the new, stop the informer
+					glog.V(2).Infof("Resource %s no longer exists or no longer supports watch, stopping its informer\n", gvr.String())
+					close(stopper)
+					delete(stoppers, gvr)
+				}
+			}
+			// Now, loop through the new list, which after the above deletions, contains only stuff that needs to
+			// have a new informer created for it.
+			for gvr := range gvrList {
+				glog.V(2).Infof("Found new resource %s, creating informer\n", gvr.String())
+				// Using our custom informer.
+				informer, _ := InformerForResource(gvr)
+
+				// Set up handler to pass this informer's resources into transformer
+				informer.AddFunc = createInformerAddHandler(gvr.Resource)
+				informer.UpdateFunc = createInformerUpdateHandler(gvr.Resource)
+				informer.DeleteFunc = informerDeleteHandler
+
+				stopper := make(chan struct{})
+				stoppers[gvr] = stopper
+				go informer.Run(stopper)
+				// This wait serializes the informer initialization. It is needed to avoid a
+				// spike in memory when the collector starts.
+				informer.WaitUntilInitialized(time.Duration(10) * time.Second) // Times out after 10 seconds.
+			}
+			glog.V(2).Info("Total informers running: ", len(stoppers))
+
+			initialized <- struct{}{}
+		}
+
+		time.Sleep(time.Duration(config.Cfg.RediscoverRateMS) * time.Millisecond)
+	}
+}


### PR DESCRIPTION
### Related Issue
N/A
### Description of changes
- Refactor to simplify main by moving logic to start informers to a separate file.
- Better implementation comments.
