### PR TITLE
ACM-5402: Fixes problem when synchronizing informers

### DIFF
--- a/pkg/informer/runInformers.go
+++ b/pkg/informer/runInformers.go
@@ -19,7 +19,7 @@ import (
 func RunInformers(initialized chan interface{}, upsertTransformer tr.Transformer, reconciler *rec.Reconciler) {
 
 	// These functions return handler functions, which are then used in creation of the informers.
-	createInformerAddHandler := func(resourceName string) func(interface{}) {
+	createInformAddHandler := func(resourceName string) func(interface{}) {
 		return func(obj interface{}) {
 			resource := obj.(*unstructured.Unstructured)
 			upsert := tr.Event{
@@ -32,7 +32,7 @@ func RunInformers(initialized chan interface{}, upsertTransformer tr.Transformer
 		}
 	}
 
-	createInformerUpdateHandler := func(resourceName string) func(interface{}, interface{}) {
+	createInformUpdateHandler := func(resourceName string) func(interface{}, interface{}) {
 		return func(oldObj, newObj interface{}) {
 			resource := newObj.(*unstructured.Unstructured)
 			upsert := tr.Event{
@@ -45,7 +45,7 @@ func RunInformers(initialized chan interface{}, upsertTransformer tr.Transformer
 		}
 	}
 
-	informerDeleteHandler := func(obj interface{}) {
+	informDeleteHandler := func(obj interface{}) {
 		resource := obj.(*unstructured.Unstructured)
 		// We don't actually have anything to transform in the case of a deletion, so we manually construct the NodeEvent
 		ne := tr.NodeEvent{
@@ -65,13 +65,13 @@ func RunInformers(initialized chan interface{}, upsertTransformer tr.Transformer
 	stoppers := make(map[schema.GroupVersionResource]chan struct{})
 
 	// Initialize the informers
-	syncInformers(*discoveryClient, stoppers, createInformerAddHandler, createInformerUpdateHandler, informerDeleteHandler)
+	syncInformers(*discoveryClient, stoppers, createInformAddHandler, createInformUpdateHandler, informDeleteHandler)
 	// Close the initialized channel so that we can start the sender.
 	close(initialized)
 	// Continue polling to keep the informers synchronized when CRDs are added or deleted in the cluster.
 	for {
 		time.Sleep(time.Duration(config.Cfg.RediscoverRateMS) * time.Millisecond)
-		syncInformers(*discoveryClient, stoppers, createInformerAddHandler, createInformerUpdateHandler, informerDeleteHandler)
+		syncInformers(*discoveryClient, stoppers, createInformAddHandler, createInformUpdateHandler, informDeleteHandler)
 	}
 }
 

--- a/pkg/informer/runInformers.go
+++ b/pkg/informer/runInformers.go
@@ -57,58 +57,72 @@ func RunInformers(initialized chan interface{}, upsertTransformer tr.Transformer
 		reconciler.Input <- ne
 	}
 
+	// We keep each of the informer's stopper channel in a map, so we can stop them if the resource is no longer valid.
+	stoppers := make(map[schema.GroupVersionResource]chan struct{})
+
+	// Initialize the informers
+	syncInformers(stoppers, createInformerAddHandler, createInformerUpdateHandler, informerDeleteHandler)
+	// Close the initialized channel so that we can start the sender.
+	close(initialized)
+	// Continue polling to keep the informers synchronized when CRDs are added or deleted in the cluster.
+	for {
+		time.Sleep(time.Duration(config.Cfg.RediscoverRateMS) * time.Millisecond)
+		syncInformers(stoppers, createInformerAddHandler, createInformerUpdateHandler, informerDeleteHandler)
+	}
+}
+
+// Start or stop informers to match the resources (CRDs) available in the cluster.
+func syncInformers(stoppers map[schema.GroupVersionResource]chan struct{},
+	createInformerAddHandler func(string) func(interface{}),
+	createInformerUpdateHandler func(string) func(interface{}, interface{}),
+	informerDeleteHandler func(obj interface{})) {
+
+	glog.V(2).Infof("Synchronizing informers. Informers running: %d", len(stoppers))
+
 	// Get kubernetes client for discovering resource types
 	discoveryClient := config.GetDiscoveryClient()
 
-	// We keep each of the informer's stopper channel in a map, so we can stop them if the resource is no longer valid.
-	stoppers := make(map[schema.GroupVersionResource]chan struct{})
-	for {
-		gvrList, err := SupportedResources(discoveryClient)
-		if err != nil {
-			glog.Error("Failed to get complete list of supported resources: ", err)
-		}
+	gvrList, err := SupportedResources(discoveryClient)
+	if err != nil {
+		glog.Error("Failed to get complete list of supported resources: ", err)
+	}
 
-		// Sometimes a partial list will be returned even if there is an error.
-		// This could happen during install when a CRD hasn't fully initialized.
-		if gvrList != nil {
-			// Loop through the previous list of resources. If we find the entry in the new list we delete it so
-			// that we don't end up with 2 informers. If we don't find it, we stop the informer that's currently
-			// running because the resource no longer exists (or no longer supports watch).
-			for gvr, stopper := range stoppers {
-				// If this still exists in the new list, delete it from there as we don't want to recreate an informer
-				if _, ok := gvrList[gvr]; ok {
-					delete(gvrList, gvr)
-					continue
-				} else { // if it's in the old and NOT in the new, stop the informer
-					glog.V(2).Infof("Resource %s no longer exists or no longer supports watch, stopping its informer\n", gvr.String())
-					close(stopper)
-					delete(stoppers, gvr)
-				}
+	// Sometimes a partial list will be returned even if there is an error.
+	// This could happen during install when a CRD hasn't fully initialized.
+	if gvrList != nil {
+		// Loop through the previous list of resources. If we find the entry in the new list we delete it so
+		// that we don't end up with 2 informers. If we don't find it, we stop the informer that's currently
+		// running because the resource no longer exists (or no longer supports watch).
+		for gvr, stopper := range stoppers {
+			// If this still exists in the new list, delete it from there as we don't want to recreate an informer
+			if _, ok := gvrList[gvr]; ok {
+				delete(gvrList, gvr)
+				continue
+			} else { // if it's in the old and NOT in the new, stop the informer
+				glog.V(2).Infof("Stopping informer: %s", gvr.String())
+				close(stopper)
+				delete(stoppers, gvr)
 			}
-			// Now, loop through the new list, which after the above deletions, contains only stuff that needs to
-			// have a new informer created for it.
-			for gvr := range gvrList {
-				glog.V(2).Infof("Found new resource %s, creating informer\n", gvr.String())
-				// Using our custom informer.
-				informer, _ := InformerForResource(gvr)
-
-				// Set up handler to pass this informer's resources into transformer
-				informer.AddFunc = createInformerAddHandler(gvr.Resource)
-				informer.UpdateFunc = createInformerUpdateHandler(gvr.Resource)
-				informer.DeleteFunc = informerDeleteHandler
-
-				stopper := make(chan struct{})
-				stoppers[gvr] = stopper
-				go informer.Run(stopper)
-				// This wait serializes the informer initialization. It is needed to avoid a
-				// spike in memory when the collector starts.
-				informer.WaitUntilInitialized(time.Duration(10) * time.Second) // Times out after 10 seconds.
-			}
-			glog.V(2).Info("Total informers running: ", len(stoppers))
-
-			initialized <- struct{}{}
 		}
+		// Now, loop through the new list, which after the above deletions, contains only stuff that needs to
+		// have a new informer created for it.
+		for gvr := range gvrList {
+			glog.V(2).Infof("Starting informer: %s", gvr.String())
+			// Using our custom informer.
+			informer, _ := InformerForResource(gvr)
 
-		time.Sleep(time.Duration(config.Cfg.RediscoverRateMS) * time.Millisecond)
+			// Set up handler to pass this informer's resources into transformer
+			informer.AddFunc = createInformerAddHandler(gvr.Resource)
+			informer.UpdateFunc = createInformerUpdateHandler(gvr.Resource)
+			informer.DeleteFunc = informerDeleteHandler
+
+			stopper := make(chan struct{})
+			stoppers[gvr] = stopper
+			go informer.Run(stopper)
+			// This wait serializes the informer initialization. It is needed to avoid a
+			// spike in memory when the collector starts.
+			informer.WaitUntilInitialized(time.Duration(10) * time.Second) // Times out after 10 seconds.
+		}
+		glog.V(2).Info("Done synchronizing informers. Informers running: ", len(stoppers))
 	}
 }

--- a/pkg/informer/runInformers_test.go
+++ b/pkg/informer/runInformers_test.go
@@ -15,6 +15,15 @@ import (
 	restclient "k8s.io/client-go/rest"
 )
 
+var mockAddFn = func(s string) func(interface{}) {
+	return func(o interface{}) {}
+}
+var mockUpdateFn = func(s string) func(interface{}, interface{}) {
+	return func(old interface{}, new interface{}) {}
+}
+
+var mockDeleteHandler = func(obj interface{}) {}
+
 func fakeDiscoveryClient() (*httptest.Server, discovery.DiscoveryClient) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		var obj interface{}
@@ -53,15 +62,6 @@ func fakeDiscoveryClient() (*httptest.Server, discovery.DiscoveryClient) {
 
 	return server, *client
 }
-
-var mockAddFn = func(s string) func(interface{}) {
-	return func(o interface{}) {}
-}
-var mockUpdateFn = func(s string) func(interface{}, interface{}) {
-	return func(old interface{}, new interface{}) {}
-}
-
-var mockDeleteHandler = func(obj interface{}) {}
 
 func Test_syncInformers(t *testing.T) {
 

--- a/pkg/informer/runInformers_test.go
+++ b/pkg/informer/runInformers_test.go
@@ -60,7 +60,10 @@ func fakeDiscoveryClient2() discovery.DiscoveryClient {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write(output)
+		_, writeErr := w.Write(output)
+		if writeErr != nil {
+			fmt.Println("error", err)
+		}
 	}))
 	defer server.Close()
 	client := discovery.NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})

--- a/pkg/informer/runInformers_test.go
+++ b/pkg/informer/runInformers_test.go
@@ -1,0 +1,93 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package informer
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	restclient "k8s.io/client-go/rest"
+)
+
+// func fakeDiscoveryClient() *fake.FakeDiscovery {
+// 	client := fakeclientset.NewSimpleClientset()
+// 	fakeDiscovery := client.Discovery().(*fake.FakeDiscovery)
+
+// 	// fakeDiscovery.Fake.Resources = fakeclientset.
+
+// 	resources, _ := fakeDiscovery.ServerPreferredResources()
+// 	fmt.Printf("fake resources: %+v\n", resources)
+
+// 	return fakeDiscovery
+
+// }
+
+func fakeDiscoveryClient2() discovery.DiscoveryClient {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var obj interface{}
+		switch req.URL.Path {
+		case "/api":
+			obj = &metav1.APIVersions{
+				Versions: []string{
+					"v1",
+				},
+			}
+		case "/apis":
+			obj = &metav1.APIGroupList{
+				Groups: []metav1.APIGroup{
+					{
+						Name: "extensions",
+						Versions: []metav1.GroupVersionForDiscovery{
+							{GroupVersion: "extensions/v1beta1"},
+						},
+					},
+				},
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		output, err := json.Marshal(obj)
+		if err != nil {
+			// t.Fatalf("unexpected encoding error: %v", err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(output)
+	}))
+	defer server.Close()
+	client := discovery.NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
+
+	resources, _ := client.ServerPreferredResources()
+	fmt.Printf("\n>>>fake resources: %+v\n", resources)
+
+	return *client //.(*discovery.DiscoveryInterface)
+}
+
+func Test_syncInformers(t *testing.T) {
+
+	mockStoppers := make(map[schema.GroupVersionResource]chan struct{})
+	mockAddFn := func(s string) func(interface{}) {
+		return func(o interface{}) {
+			t.Log("Procesing add...")
+		}
+	}
+	mockUpdateFn := func(s string) func(interface{}, interface{}) {
+		return func(old interface{}, new interface{}) {
+			t.Log("Procesing update...")
+		}
+	}
+	mockDeleteHandler := func(obj interface{}) {
+		t.Log("Procesing delete...")
+	}
+	fakeClient := fakeDiscoveryClient2()
+
+	syncInformers(fakeClient, mockStoppers, mockAddFn, mockUpdateFn, mockDeleteHandler)
+}

--- a/pkg/informer/supportedResources.go
+++ b/pkg/informer/supportedResources.go
@@ -85,7 +85,7 @@ func isResourceAllowed(group, kind string, allowedList []Resource, deniedList []
 	return false
 }
 
-// Helper funtion to get map of resource object
+// Helper function to get map of resource object
 func isResourceMatchingList(resourceList []Resource, group, kind string) (string, string, bool) {
 	for _, r := range resourceList {
 		for _, g := range r.ApiGroups {
@@ -100,7 +100,7 @@ func isResourceMatchingList(resourceList []Resource, group, kind string) (string
 }
 
 // Returns a map containing all the GVRs on the cluster of resources that support WATCH (ignoring clusters and events).
-func SupportedResources(discoveryClient *discovery.DiscoveryClient) (map[schema.GroupVersionResource]struct{}, error) {
+func SupportedResources(discoveryClient discovery.DiscoveryClient) (map[schema.GroupVersionResource]struct{}, error) {
 	ctx := context.TODO()
 	// Next step is to discover all the gettable resource types that the kuberenetes api server knows about.
 	supportedResources := []*machineryV1.APIResourceList{}

--- a/pkg/informer/supportedResources.go
+++ b/pkg/informer/supportedResources.go
@@ -50,7 +50,7 @@ func isResourceAllowed(group, kind string, allowedList []Resource, deniedList []
 	// Deny all apiResources with kind in list
 	for _, name := range list {
 		if kind == name {
-			glog.V(2).Infof("Deny resource [group: '%s' kind: %s]. Search collector doesn't support it.", group, kind)
+			glog.V(3).Infof("Deny resource [group: '%s' kind: %s]. Search collector doesn't support it.", group, kind)
 			return false
 		}
 	}
@@ -62,9 +62,9 @@ func isResourceAllowed(group, kind string, allowedList []Resource, deniedList []
 		// Check if resource is also in the allow list.
 		_, _, allowed := isResourceMatchingList(allowedList, group, kind)
 		if allowed {
-			glog.V(2).Infof("Deny Resource [group: '%s' kind: %s]. Resource present in both allow and deny rule.", group, kind)
+			glog.V(3).Infof("Deny Resource [group: '%s' kind: %s]. Resource present in both allow and deny rule.", group, kind)
 		} else {
-			glog.V(2).Infof("Deny resource [group: '%s' kind: %s]. Matched rule [group: '%s' kind: %s].", group, kind, g, k)
+			glog.V(3).Infof("Deny resource [group: '%s' kind: %s]. Matched rule [group: '%s' kind: %s].", group, kind, g, k)
 		}
 		return false
 	}
@@ -72,20 +72,20 @@ func isResourceAllowed(group, kind string, allowedList []Resource, deniedList []
 	// If allowList not provided, interpret it as allow all resources.
 	// otherwise allow only the resources declared in allow list.
 	if len(allowedList) == 0 {
-		glog.V(2).Infof("Allow resource [group: '%s' kind: %s]. AllowList is empty.", group, kind)
+		glog.V(3).Infof("Allow resource [group: '%s' kind: %s]. AllowList is empty.", group, kind)
 		return true
 	} else {
 		g, k, allowed := isResourceMatchingList(allowedList, group, kind)
 		if allowed {
-			glog.V(2).Infof("Allow resource [group: '%s' kind: %s]. Matched [group: '%s' kind: %s].", group, kind, g, k)
+			glog.V(3).Infof("Allow resource [group: '%s' kind: %s]. Matched [group: '%s' kind: %s].", group, kind, g, k)
 			return true
 		}
 	}
-	glog.V(2).Infof("Deny resource [group: '%s' kind: %s]. It doesn't match any allow or deny rule.", group, kind)
+	glog.V(3).Infof("Deny resource [group: '%s' kind: %s]. It doesn't match any allow or deny rule.", group, kind)
 	return false
 }
 
-//helper funtion to get map of resource object
+// Helper funtion to get map of resource object
 func isResourceMatchingList(resourceList []Resource, group, kind string) (string, string, bool) {
 	for _, r := range resourceList {
 		for _, g := range r.ApiGroups {
@@ -117,10 +117,10 @@ func SupportedResources(discoveryClient *discovery.DiscoveryClient) (map[schema.
 	kubeClient := config.GetKubeClient(config.GetKubeConfig())
 
 	// locate the search-collector-config ConfigMap
-	cm, err2 := kubeClient.CoreV1().ConfigMaps(config.Cfg.PodNamespace).
+	cm, cmErr := kubeClient.CoreV1().ConfigMaps(config.Cfg.PodNamespace).
 		Get(ctx, "search-collector-config", metav1.GetOptions{})
-	if err2 != nil {
-		glog.Info("Didn't find ConfigMap with name search-collector-config. Will collect all resources. ", err2)
+	if cmErr != nil {
+		glog.Info("Collecting all resources. ConfigMap search-collector-config is not present.", cmErr)
 	}
 
 	// parse alloy/deny from config
@@ -161,7 +161,6 @@ func SupportedResources(discoveryClient *discovery.DiscoveryClient) (map[schema.
 
 		watchList.APIResources = watchResources
 		supportedResources = append(supportedResources, &watchList)
-
 	}
 
 	// Use handy converter function to convert into GroupVersionResource objects, which we need in order to make informers

--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -190,7 +190,7 @@ func (s *Sender) sendWithRetry(payload Payload, expectedTotalResources int, expe
 // Pointer receiver because Sender contains a mutex - that freaked the linter out even though it
 // doesn't use the mutex. Changed it so that if we do need to use the mutex we wont have any problems.
 func (s *Sender) send(payload Payload, expectedTotalResources int, expectedTotalEdges int) error {
-	glog.Infof("Sending Resources { request: %6d, add: %2d, update: %2d, delete: %2d, edge add: %2d, edge delete: %2d }",
+	glog.Infof("Sending Resources { request: %d, add: %d, update: %d, delete: %d edge add: %d edge delete: %d }",
 		payload.RequestId, len(payload.AddResources), len(payload.UpdatedResources), len(payload.DeletedResources),
 		len(payload.AddEdges), len(payload.DeleteEdges))
 

--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -190,7 +190,7 @@ func (s *Sender) sendWithRetry(payload Payload, expectedTotalResources int, expe
 // Pointer receiver because Sender contains a mutex - that freaked the linter out even though it
 // doesn't use the mutex. Changed it so that if we do need to use the mutex we wont have any problems.
 func (s *Sender) send(payload Payload, expectedTotalResources int, expectedTotalEdges int) error {
-	glog.Infof("Sending Resources { request: %d, add: %d, update: %d, delete: %d edge add: %d edge delete: %d }",
+	glog.Infof("Sending Resources { request: %08d, add: %d, update: %d, delete: %d edge add: %d edge delete: %d }",
 		payload.RequestId, len(payload.AddResources), len(payload.UpdatedResources), len(payload.DeletedResources),
 		len(payload.AddEdges), len(payload.DeleteEdges))
 

--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -190,7 +190,7 @@ func (s *Sender) sendWithRetry(payload Payload, expectedTotalResources int, expe
 // Pointer receiver because Sender contains a mutex - that freaked the linter out even though it
 // doesn't use the mutex. Changed it so that if we do need to use the mutex we wont have any problems.
 func (s *Sender) send(payload Payload, expectedTotalResources int, expectedTotalEdges int) error {
-	glog.Infof("Sending Resources { request: %08d, add: %d, update: %d, delete: %d edge add: %d edge delete: %d }",
+	glog.Infof("Sending Resources { request: %6d, add: %2d, update: %2d, delete: %2d, edge add: %2d, edge delete: %2d }",
 		payload.RequestId, len(payload.AddResources), len(payload.UpdatedResources), len(payload.DeletedResources),
 		len(payload.AddEdges), len(payload.DeleteEdges))
 
@@ -296,7 +296,7 @@ func (s *Sender) Sync() error {
 func (s *Sender) StartSendLoop() {
 
 	// Used for exponential backoff, increased each interval. Has to be a float64 since I use it with math.Exp2()
-	backoffFactor := float64(0)
+	backoffFactor := float64(1) // Note: must be 1. Using 0 will send the next payload immediately.
 
 	for {
 		glog.V(3).Info("Beginning Send Cycle")
@@ -311,11 +311,11 @@ func (s *Sender) StartSendLoop() {
 			}
 		} else {
 			glog.V(2).Info("Send Cycle Completed Successfully")
-			backoffFactor = float64(0) // Reset backoff to 0 because we had a sucessful send.
+			backoffFactor = float64(1) // Reset backoff to 1 because we had a sucessful send.
 		}
 		nextSleepInterval := config.Cfg.ReportRateMS * int(math.Exp2(backoffFactor))
 		timeToSleep := time.Duration(min(nextSleepInterval, config.Cfg.MaxBackoffMS)) * time.Millisecond
-		if backoffFactor > 0 {
+		if backoffFactor > 1 {
 			glog.Warning("Backing off send interval because of error response from aggregator. Sleeping for ", timeToSleep)
 		}
 		// Sleep either for the current backed off interval, or the maximum time defined in the config

--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -296,7 +296,7 @@ func (s *Sender) Sync() error {
 func (s *Sender) StartSendLoop() {
 
 	// Used for exponential backoff, increased each interval. Has to be a float64 since I use it with math.Exp2()
-	backoffFactor := float64(1) // Note: must be 1. Using 0 will send the next payload immediately.
+	backoffFactor := float64(0)
 
 	for {
 		glog.V(3).Info("Beginning Send Cycle")
@@ -311,11 +311,11 @@ func (s *Sender) StartSendLoop() {
 			}
 		} else {
 			glog.V(2).Info("Send Cycle Completed Successfully")
-			backoffFactor = float64(1) // Reset backoff to 1 because we had a sucessful send.
+			backoffFactor = float64(0) // Reset backoff to 0 because we had a sucessful send.
 		}
 		nextSleepInterval := config.Cfg.ReportRateMS * int(math.Exp2(backoffFactor))
 		timeToSleep := time.Duration(min(nextSleepInterval, config.Cfg.MaxBackoffMS)) * time.Millisecond
-		if backoffFactor > 1 {
+		if backoffFactor > 0 {
 			glog.Warning("Backing off send interval because of error response from aggregator. Sleeping for ", timeToSleep)
 		}
 		// Sleep either for the current backed off interval, or the maximum time defined in the config


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-5402

### Description of changes
- The loop to poll CRDs and start the informers was blocked on `initialized <- struct{}{}`
- Refactored the code to write to the initialized channel only once.
- Minor log adjustments.