### PR TITLE
Add jitter to backoff logic

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,7 +55,7 @@ type Config struct {
 	KubeConfig           string       `env:"KUBECONFIG"`         // Local kubeconfig path
 	MaxBackoffMS         int          `env:"MAX_BACKOFF_MS"`     // Maximum backoff in ms to wait after error
 	RediscoverRateMS     int          `env:"REDISCOVER_RATE_MS"` // Interval(ms) to poll for changes to CRDs
-	RetryJitterMS        int          `env:"RETRY_JITTER_MS"`    // Random for jitter added on error backoff
+	RetryJitterMS        int          `env:"RETRY_JITTER_MS"`    // Random jitter added to backoff wait.
 	ReportRateMS         int          `env:"REPORT_RATE_MS"`     // Interval(ms) to send changes to the aggregator
 	RuntimeMode          string       `env:"RUNTIME_MODE"`       // Running mode (development or production)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,7 @@ const (
 	DEFAULT_MAX_BACKOFF_MS     = 600000 // 10 min
 	DEFAULT_REDISCOVER_RATE_MS = 120000 // 2 min
 	DEFAULT_REPORT_RATE_MS     = 5000   // 5 seconds
+	DEFAULT_RETRY_JITTER_MS    = 5000   // 5 seconds
 	DEFAULT_RUNTIME_MODE       = "production"
 )
 
@@ -54,6 +55,7 @@ type Config struct {
 	KubeConfig           string       `env:"KUBECONFIG"`         // Local kubeconfig path
 	MaxBackoffMS         int          `env:"MAX_BACKOFF_MS"`     // Maximum backoff in ms to wait after error
 	RediscoverRateMS     int          `env:"REDISCOVER_RATE_MS"` // Interval(ms) to poll for changes to CRDs
+	RetryJitterMS        int          `env:"RETRY_JITTER_MS"`    // Random for jitter added on error backoff
 	ReportRateMS         int          `env:"REPORT_RATE_MS"`     // Interval(ms) to send changes to the aggregator
 	RuntimeMode          string       `env:"RUNTIME_MODE"`       // Running mode (development or production)
 }
@@ -103,6 +105,7 @@ func InitConfig() {
 	setDefaultInt(&Cfg.MaxBackoffMS, "MAX_BACKOFF_MS", DEFAULT_MAX_BACKOFF_MS)
 	setDefaultInt(&Cfg.RediscoverRateMS, "REDISCOVER_RATE_MS", DEFAULT_REDISCOVER_RATE_MS)
 	setDefaultInt(&Cfg.ReportRateMS, "REPORT_RATE_MS", DEFAULT_REPORT_RATE_MS)
+	setDefaultInt(&Cfg.RetryJitterMS, "RETRY_JITTER_MS", DEFAULT_RETRY_JITTER_MS)
 
 	defaultKubePath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
 	if _, err := os.Stat(defaultKubePath); os.IsNotExist(err) {

--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -332,7 +332,7 @@ func min(a, b int) int {
 
 // Compute the time interval to wait before next send or retry (backoff).
 func sendInterval(retry int) time.Duration {
-	nextInterval := config.Cfg.ReportRateMS*int(math.Exp2(float64(retry))) + addJitter()
+	nextInterval := int(1000*math.Exp2(float64(retry))) + addJitter()
 	return time.Duration(min(nextInterval, config.Cfg.MaxBackoffMS)) * time.Millisecond
 }
 

--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -336,7 +336,7 @@ func sendInterval(retry int) time.Duration {
 	return time.Duration(min(nextInterval, config.Cfg.MaxBackoffMS)) * time.Millisecond
 }
 
-// Generate a random jitter to randomize the backoff retry interval.
+// Generate a random jitter to add to the backoff retry to prevent clients from retrying at the same interval.
 func addJitter() int {
 	max := big.NewInt(int64(config.Cfg.RetryJitterMS))
 	j, err := rand.Int(rand.Reader, max)

--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -180,7 +180,7 @@ func (s *Sender) sendWithRetry(payload Payload, expectedTotalResources int, expe
 			time.Sleep(nextRetryWait)
 			config.InitConfig() // re-initialize config to get the latest certificate.
 			s.reloadSender()    // reload sender variables - Aggregator URL, path and client
-			return sendError
+			continue
 		}
 		return sendError
 	}

--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -339,7 +339,6 @@ func sendInterval(retry int) time.Duration {
 // Generate a random jitter to randomize the backoff retry interval.
 func addJitter() int {
 	max := big.NewInt(int64(config.Cfg.RetryJitterMS))
-	fmt.Println("MAX: ", max)
 	j, err := rand.Int(rand.Reader, max)
 	if err != nil {
 		return 0

--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -168,16 +168,16 @@ func (s *Sender) sendWithRetry(payload Payload, expectedTotalResources int, expe
 	for {
 		sendError := s.send(payload, expectedTotalResources, expectedTotalEdges)
 		retry++
-		waitMS := int(math.Min(float64(retry*15*1000), float64(config.Cfg.MaxBackoffMS)))
+		nextRetryWait := sendInterval(retry)
 
 		if sendError != nil && sendError.Error() == "Aggregator busy" {
-			glog.Warningf("Received busy response from Aggregator. Resending in %d ms.", waitMS)
-			time.Sleep(time.Duration(waitMS) * time.Millisecond)
+			glog.Warningf("Received busy response from Indexer. Resending in %s.", nextRetryWait)
+			time.Sleep(nextRetryWait)
 			continue
 		} else if sendError != nil {
-			glog.Warningf("Received error response [%s] from Aggregator. Resending in %d ms after resetting config.",
-				sendError.Error(), waitMS)
-			time.Sleep(time.Duration(waitMS) * time.Millisecond)
+			glog.Warningf("Received error response [%s] from Indexer. Resetting config and resending in %s.",
+				sendError.Error(), nextRetryWait)
+			time.Sleep(nextRetryWait)
 			config.InitConfig() // re-initialize config to get the latest certificate.
 			s.reloadSender()    // reload sender variables - Aggregator URL, path and client
 			return sendError
@@ -296,30 +296,29 @@ func (s *Sender) Sync() error {
 func (s *Sender) StartSendLoop() {
 
 	// Used for exponential backoff, increased each interval. Has to be a float64 since I use it with math.Exp2()
-	backoffFactor := float64(1) // Note: must be 1. Using 0 will send the next payload immediately.
+	backoffFactor := 1 // Note: must be 1. Using 0 will send the next payload immediately.
 
 	for {
 		glog.V(3).Info("Beginning Send Cycle")
 		err := s.Sync()
 		if err != nil {
 			glog.Error("SEND ERROR: ", err)
-			// Increase the backoffFactor, doubling the wait time. Stops doubling it after it passes the max
+			// Increase the backoffFactor, doubling the wait time. Stops increasing after it passes the max
 			// wait time so that we don't overflow int. Can be changed with env:MAX_BACKOFF_MS
-			if time.Duration(config.Cfg.ReportRateMS)*time.Duration(math.Exp2(backoffFactor))*time.Millisecond <
-				time.Duration(config.Cfg.MaxBackoffMS)*time.Millisecond {
+			if sendInterval(backoffFactor) < time.Duration(config.Cfg.MaxBackoffMS)*time.Millisecond {
 				backoffFactor++
 			}
 		} else {
 			glog.V(2).Info("Send Cycle Completed Successfully")
-			backoffFactor = float64(1) // Reset backoff to 1 because we had a sucessful send.
+			backoffFactor = 1 // Reset backoff to 1 because we had a sucessful send.
 		}
-		nextSleepInterval := config.Cfg.ReportRateMS * int(math.Exp2(backoffFactor))
-		timeToSleep := time.Duration(min(nextSleepInterval, config.Cfg.MaxBackoffMS)) * time.Millisecond
+
+		nextSendWait := sendInterval(backoffFactor)
 		if backoffFactor > 1 {
-			glog.Warning("Backing off send interval because of error response from aggregator. Sleeping for ", timeToSleep)
+			glog.Warningf("Error during last sync. Resending in %s.", nextSendWait)
 		}
 		// Sleep either for the current backed off interval, or the maximum time defined in the config
-		time.Sleep(timeToSleep)
+		time.Sleep(nextSendWait)
 	}
 }
 
@@ -329,4 +328,20 @@ func min(a, b int) int {
 		return b
 	}
 	return a
+}
+
+// Compute the time interval to wait before next send or retry (backoff).
+func sendInterval(retry int) time.Duration {
+	nextInterval := config.Cfg.ReportRateMS*int(math.Exp2(float64(retry))) + addJitter()
+	return time.Duration(min(nextInterval, config.Cfg.MaxBackoffMS)) * time.Millisecond
+}
+
+// Generate a random jitter to randomize the backoff retry interval.
+func addJitter() int {
+	max := big.NewInt(int64(config.Cfg.RetryJitterMS))
+	j, err := rand.Int(rand.Reader, max)
+	if err != nil {
+		return 0
+	}
+	return int(j.Int64())
 }

--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -339,6 +339,7 @@ func sendInterval(retry int) time.Duration {
 // Generate a random jitter to randomize the backoff retry interval.
 func addJitter() int {
 	max := big.NewInt(int64(config.Cfg.RetryJitterMS))
+	fmt.Println("MAX: ", max)
 	j, err := rand.Int(rand.Reader, max)
 	if err != nil {
 		return 0

--- a/pkg/send/sender_test.go
+++ b/pkg/send/sender_test.go
@@ -129,14 +129,18 @@ func Test_minIsA(t *testing.T) {
 }
 
 func Test_sendInterval(t *testing.T) {
-
 	wait := sendInterval(1)
 	assert.GreaterOrEqual(t, wait.Milliseconds(), int64(1000))
 	assert.LessOrEqual(t, wait.Milliseconds(), int64(7000))
 }
 
 func Test_sendInterval_maxBackoff(t *testing.T) {
+	wait := sendInterval(50)
+	assert.Equal(t, int64(600000), wait.Milliseconds())
+}
 
-	wait := sendInterval(100)
-	assert.LessOrEqual(t, wait.Milliseconds(), int64(600000))
+func Test_sendInterval_minBackoff(t *testing.T) {
+	wait := sendInterval(0)
+	assert.GreaterOrEqual(t, wait.Milliseconds(), int64(0))
+	assert.LessOrEqual(t, wait.Milliseconds(), int64(5000))
 }

--- a/pkg/send/sender_test.go
+++ b/pkg/send/sender_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stolostron/search-collector/pkg/transforms"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSenderWrongCount(t *testing.T) {
@@ -116,4 +117,12 @@ func TestSenderSuccessful(t *testing.T) {
 	if err != nil {
 		t.Fatal("send function reports error:", err)
 	}
+}
+
+func Test_sendInterval(t *testing.T) {
+
+	next := sendInterval(1)
+
+	assert.GreaterOrEqual(t, next.Milliseconds(), int64(5000))
+	assert.LessOrEqual(t, next.Milliseconds(), int64(15000))
 }

--- a/pkg/send/sender_test.go
+++ b/pkg/send/sender_test.go
@@ -119,10 +119,24 @@ func TestSenderSuccessful(t *testing.T) {
 	}
 }
 
+func Test_minIsB(t *testing.T) {
+	min := min(11, 99)
+	assert.Equal(t, 11, min)
+}
+func Test_minIsA(t *testing.T) {
+	min := min(99, 11)
+	assert.Equal(t, 11, min)
+}
+
 func Test_sendInterval(t *testing.T) {
 
-	next := sendInterval(1)
+	wait := sendInterval(1)
+	assert.GreaterOrEqual(t, wait.Milliseconds(), int64(1000))
+	assert.LessOrEqual(t, wait.Milliseconds(), int64(7000))
+}
 
-	assert.GreaterOrEqual(t, next.Milliseconds(), int64(5000))
-	assert.LessOrEqual(t, next.Milliseconds(), int64(15000))
+func Test_sendInterval_maxBackoff(t *testing.T) {
+
+	wait := sendInterval(100)
+	assert.LessOrEqual(t, wait.Milliseconds(), int64(600000))
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=open-cluster-management_search-collector
 sonar.projectName=search-collector
 sonar.sources=.
-sonar.exclusions=**/*_test.go,**/testutils.go,**/vbh/**
+sonar.exclusions=**/*_test.go,**/testutils.go,**/vbh/**,main.go
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 sonar.test.exclusions=**/vbh/**


### PR DESCRIPTION
### Related Issue
N/A

### Description of changes
- Adds random jitter to the backoff logic to prevent collectors form getting in the same retry cycle.
