### PR TITLE
ACM-5188 Sonar security finding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ lint:
 	GOPATH=$(go env GOPATH)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.47.1
 	CGO_ENABLED=0 GOGC=25 golangci-lint run --timeout=3m
+	gosec ./...
 	
 run:
 	GOGC=25 go run main.go --v=2

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -11,6 +11,7 @@ lint:
 	GOPATH=$(go env GOPATH)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.47.1
 	CGO_ENABLED=0 GOGC=25 golangci-lint run --timeout=3m
+	gosec ./...
 	
 .PHONY: unit-test
 unit-test:

--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -200,7 +200,7 @@ func (s *Sender) send(payload Payload, expectedTotalResources int, expectedTotal
 	}
 	payloadBuffer := bytes.NewBuffer(payloadBytes)
 	resp, err := s.httpClient.Post(s.aggregatorURL+s.aggregatorSyncPath, "application/json", payloadBuffer)
-	if resp != nil {
+	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()
 	}
 	if err != nil {

--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -201,6 +201,7 @@ func (s *Sender) send(payload Payload, expectedTotalResources int, expectedTotal
 	payloadBuffer := bytes.NewBuffer(payloadBytes)
 	resp, err := s.httpClient.Post(s.aggregatorURL+s.aggregatorSyncPath, "application/json", payloadBuffer)
 	if resp != nil && resp.Body != nil {
+		// #nosec G307
 		defer resp.Body.Close()
 	}
 	if err != nil {


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-5188

### Description of changes
- Disable gosec rule G307.  This rule has been retired from gosec. [More info here.](https://github.com/securego/gosec/pull/935)
- Update makefile to run gosec with lint.
