### PR TITLE
Remove metadata from JSON payload

### DIFF
--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -201,7 +201,6 @@ func (s *Sender) send(payload Payload, expectedTotalResources int, expectedTotal
 		return err
 	}
 	payloadBuffer := bytes.NewBuffer(payloadBytes)
-
 	resp, err := s.httpClient.Post(s.aggregatorURL+s.aggregatorSyncPath, "application/json", payloadBuffer)
 	if resp != nil && resp.Body != nil {
 		// #nosec G307

--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -201,6 +201,10 @@ func (s *Sender) send(payload Payload, expectedTotalResources int, expectedTotal
 		return err
 	}
 	payloadBuffer := bytes.NewBuffer(payloadBytes)
+
+	// When sending 4886 the payload size is reduced by 210472 bytes (2742099 - 2530627) when removing the metadata.
+	// JSON payload size: 2742099 (BEFORE removing Metadata)
+	// JSON payload size: 2530627 (AFTER removing Metadata)
 	resp, err := s.httpClient.Post(s.aggregatorURL+s.aggregatorSyncPath, "application/json", payloadBuffer)
 	if resp != nil && resp.Body != nil {
 		// #nosec G307

--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -202,9 +202,6 @@ func (s *Sender) send(payload Payload, expectedTotalResources int, expectedTotal
 	}
 	payloadBuffer := bytes.NewBuffer(payloadBytes)
 
-	// When sending 4886 the payload size is reduced by 210472 bytes (2742099 - 2530627) when removing the metadata.
-	// JSON payload size: 2742099 (BEFORE removing Metadata)
-	// JSON payload size: 2530627 (AFTER removing Metadata)
 	resp, err := s.httpClient.Post(s.aggregatorURL+s.aggregatorSyncPath, "application/json", payloadBuffer)
 	if resp != nil && resp.Body != nil {
 		// #nosec G307

--- a/pkg/transforms/transformer.go
+++ b/pkg/transforms/transformer.go
@@ -57,7 +57,7 @@ type Node struct {
 	UID            string                 `json:"uid"`
 	ResourceString string                 `json:"resourceString"`
 	Properties     map[string]interface{} `json:"properties"`
-	Metadata       map[string]string
+	Metadata       map[string]string      `json:"-"` // This won't be sent to the indexer.
 }
 
 func (n Node) hasMetadata(md string) bool {


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-0000

### Description of changes
- Remove the metadata field from JSON payload sent to indexer. This is only used by the collector.
- JSON payload size is reduced by about 8%.
  - When sending 4886 resources, the payload size was reduced by 211472 bytes (2742099 - 2530627).
