### PR TITLE
Remove the _clusterNamespace property

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,8 +47,7 @@ type Config struct {
 	AggregatorURL        string       `env:"AGGREGATOR_URL"`     // URL of the Aggregator, includes port but not any path
 	AggregatorHost       string       `env:"AGGREGATOR_HOST"`    // Host of the Aggregator
 	AggregatorPort       string       `env:"AGGREGATOR_PORT"`    // Port of the Aggregator
-	ClusterName          string       `env:"CLUSTER_NAME"`       // The name of this cluster
-	ClusterNamespace     string       `env:"CLUSTER_NAMESPACE"`  // The namespace of this cluster
+	ClusterName          string       `env:"CLUSTER_NAME"`       // The name of of the cluster where this pod is running
 	PodNamespace         string       `env:"POD_NAMESPACE"`      // The namespace of this pod
 	DeployedInHub        bool         `env:"DEPLOYED_IN_HUB"`    // Tracks if deployed in the Hub or Managed cluster
 	HeartbeatMS          int          `env:"HEARTBEAT_MS"`       // Interval(ms) to send empty payload to ensure connection
@@ -85,7 +84,6 @@ func InitConfig() {
 	// Simply put, the order of preference is env -> config.json -> default constants (from left to right)
 	setDefault(&Cfg.RuntimeMode, "RUNTIME_MODE", DEFAULT_RUNTIME_MODE)
 	setDefault(&Cfg.ClusterName, "CLUSTER_NAME", DEFAULT_CLUSTER_NAME)
-	setDefault(&Cfg.ClusterNamespace, "CLUSTER_NAMESPACE", "")
 	setDefault(&Cfg.PodNamespace, "POD_NAMESPACE", DEFAULT_POD_NAMESPACE)
 
 	setDefault(&Cfg.AggregatorHost, "AGGREGATOR_HOST", DEFAULT_AGGREGATOR_HOST)
@@ -142,7 +140,7 @@ func InitConfig() {
 		}
 
 		Cfg.AggregatorURL = hubConfig.Host + "/apis/proxy.open-cluster-management.io/v1beta1/namespaces/" +
-			Cfg.ClusterNamespace + "/clusterstatuses"
+			Cfg.ClusterName + "/clusterstatuses"
 		Cfg.AggregatorConfig = hubConfig
 
 		glog.Info("Running inside klusterlet. Aggregator URL: ", Cfg.AggregatorURL)

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -33,7 +33,6 @@ func commonProperties(resource v1.Object) map[string]interface{} {
 
 	ret["name"] = resource.GetName()
 	ret["created"] = resource.GetCreationTimestamp().UTC().Format(time.RFC3339)
-	ret["_clusterNamespace"] = config.Cfg.ClusterNamespace
 	if config.Cfg.DeployedInHub {
 		ret["_hubClusterResource"] = true
 	}

--- a/pkg/transforms/genericresource.go
+++ b/pkg/transforms/genericresource.go
@@ -80,7 +80,6 @@ func genericProperties(r *unstructured.Unstructured) map[string]interface{} {
 	ret["kind"] = r.GetKind()
 	ret["name"] = r.GetName()
 	ret["created"] = r.GetCreationTimestamp().UTC().Format(time.RFC3339)
-	ret["_clusterNamespace"] = config.Cfg.ClusterNamespace
 	if config.Cfg.DeployedInHub {
 		ret["_hubClusterResource"] = true
 	}

--- a/pkg/transforms/helmrelease.go
+++ b/pkg/transforms/helmrelease.go
@@ -53,8 +53,6 @@ func (h HelmReleaseResource) BuildNode() Node {
 
 	if config.Cfg.DeployedInHub {
 		node.Properties["_hubClusterResource"] = true
-	} else {
-		node.Properties["_clusterNamespace"] = config.Cfg.ClusterNamespace
 	}
 
 	if h.Release != nil {

--- a/pkg/transforms/helmrelease_test.go
+++ b/pkg/transforms/helmrelease_test.go
@@ -36,6 +36,5 @@ func TestTransformHelmRelease(t *testing.T) {
 	AssertEqual("namespace", node.Properties["namespace"], "default", t)
 	AssertEqual("updated", node.Properties["updated"], "2019-07-18T14:58:37Z", t)
 	AssertEqual("_hubClusterResource", node.Properties["_hubClusterResource"], true, t)
-	AssertEqual("_clusterNamespace", node.Properties["_clusterNamespace"], nil, t)
 
 }


### PR DESCRIPTION
### Related Issue
N/A

### Description of changes
- Removes the `_clusterNamespace` property.
- Prop is no longer used and it will always match the CLUSTER_NAME. 
- This property was used in the early implementation to map RBAC to the hub namespace, but we no longer support that logic.
- This is an internal property, identified by `_` so it's OK to remove without breaking the API usage. In the event it causes problems clients have access to the same data using the cluster name.
