### PR TITLE
Node status field must be a single string

### DIFF
--- a/pkg/transforms/node.go
+++ b/pkg/transforms/node.go
@@ -53,21 +53,19 @@ func NodeResourceBuilder(n *v1.Node) *NodeResource {
 
 	// Status logic is based on
 	// https://github.com/kubernetes/kubernetes/blob/master/pkg/printers/internalversion/printers.go#L1765
-	var status []string
+	// Status must be a string to avoid issues with other resources that have a status field.
+	status := "Unknown"
 	for _, condition := range n.Status.Conditions {
 		if condition.Type == v1.NodeReady {
 			if condition.Status == v1.ConditionTrue {
-				status = append(status, string(condition.Type))
+				status = string(condition.Type)
 			} else {
-				status = append(status, "Not"+string(condition.Type))
+				status = "Not" + string(condition.Type)
 			}
 		}
 	}
-	if len(status) == 0 {
-		status = append(status, "Unknown")
-	}
 	if n.Spec.Unschedulable {
-		status = append(status, "SchedulingDisabled")
+		status += "-SchedulingDisabled" // Encoding to single string to work around limitations.
 	}
 	node.Properties["status"] = status
 

--- a/pkg/transforms/node_test.go
+++ b/pkg/transforms/node_test.go
@@ -27,7 +27,7 @@ func TestTransformNode(t *testing.T) {
 	AssertEqual("osImage", node.Properties["osImage"], "Ubuntu 16.04.5 LTS", t)
 	AssertEqual("_systemUUID", node.Properties["_systemUUID"], "4BCDE0D7-CFFB-4A8F-B6F8-0026F347AD93", t)
 	AssertDeepEqual("role", node.Properties["role"], []string{"etcd", "main", "management", "proxy", "va"}, t)
-	AssertDeepEqual("status", node.Properties["status"], []string{"Ready"}, t)
+	AssertDeepEqual("status", node.Properties["status"], "Ready", t)
 }
 
 func TestNodeBuildEdges(t *testing.T) {


### PR DESCRIPTION
### Related Issue
https://github.com/stolostron/backlog/issues/27387

### Description of changes
- The Node `status` must be a single string instead of a list.
- Using list breaks the query for Pod status.
