### PR TITLE
Add config/operator/cert policy transform

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	k8s.io/apimachinery v0.28.2
 	k8s.io/client-go v13.0.0+incompatible
 	k8s.io/helm v2.17.0+incompatible
-	k8s.io/klog/v2 v2.100.1 // indirect
+	k8s.io/klog/v2 v2.100.1
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 // indirect
 	open-cluster-management.io/multicloud-operators-channel v0.8.0
 	open-cluster-management.io/multicloud-operators-subscription v0.8.0 //Use 2.0 when available

--- a/pkg/transforms/policy.go
+++ b/pkg/transforms/policy.go
@@ -11,7 +11,11 @@ Copyright (c) 2020 Red Hat, Inc.
 package transforms
 
 import (
-	p "github.com/stolostron/governance-policy-propagator/api/v1"
+	"strings"
+
+	policy "github.com/stolostron/governance-policy-propagator/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // PolicyResource ...
@@ -20,7 +24,7 @@ type PolicyResource struct {
 }
 
 // PolicyResourceBuilder ...
-func PolicyResourceBuilder(p *p.Policy) *PolicyResource {
+func PolicyResourceBuilder(p *policy.Policy) *PolicyResource {
 	node := transformCommon(p)         // Start off with the common properties
 	apiGroupVersion(p.TypeMeta, &node) // add kind, apigroup and version
 	// Extract the properties specific to this type
@@ -37,6 +41,93 @@ func PolicyResourceBuilder(p *p.Policy) *PolicyResource {
 	if okns && okpp {
 		node.Properties["_parentPolicy"] = pnamespace + "/" + ppolicy
 	}
+
+	return &PolicyResource{node: node}
+}
+
+// For cert, config, operator policies.
+// This function returns `annotations`, `_isExternal` for `source`,
+// and `severity`, `compliant`, and `remediationAction`.
+func getPolicyCommonProperties(c *unstructured.Unstructured, node Node) Node {
+	node.Properties["_isExternal"] = false
+
+	for _, m := range c.GetManagedFields() {
+		if m.Manager == "multicluster-operators-subscription" ||
+			strings.Contains(m.Manager, "argocd") {
+			node.Properties["_isExternal"] = true
+
+			break
+		}
+	}
+
+	typeMeta := metav1.TypeMeta{
+		Kind:       c.GetKind(),
+		APIVersion: c.GetAPIVersion(),
+	}
+
+	apiGroupVersion(typeMeta, &node) // add kind, apigroup and version
+
+	node.Properties["compliant"], _, _ = unstructured.NestedString(c.Object, "status", "compliant")
+
+	node.Properties["severity"], _, _ = unstructured.NestedString(c.Object, "spec", "severity")
+
+	node.Properties["remediationAction"], _, _ = unstructured.NestedString(c.Object, "spec", "remediationAction")
+
+	node.Properties["disabled"], _, _ = unstructured.NestedBool(c.Object, "spec", "disabled")
+
+	return node
+}
+
+// For cert, config policies.
+func StandalonePolicyResourceBuilder(c *unstructured.Unstructured) *PolicyResource {
+	node := transformCommon(c) // Start off with the common properties
+
+	return &PolicyResource{node: getPolicyCommonProperties(c, node)}
+}
+
+func OperatorPolicyResourceBuilder(c *unstructured.Unstructured) *PolicyResource {
+	node := transformCommon(c) // Start off with the common properties
+
+	node = getPolicyCommonProperties(c, node)
+
+	var deploymentAvailable bool
+	var upgradeAvailable bool
+
+	conditions, _, _ := unstructured.NestedSlice(c.Object, "status", "conditions")
+	for _, condition := range conditions {
+		mapCondition, ok := condition.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		conditionType, found, err := unstructured.NestedString(mapCondition, "type")
+		if !found || err != nil {
+			continue
+		}
+
+		conditionReason, found, err := unstructured.NestedString(mapCondition, "reason")
+		if !found || err != nil {
+			continue
+		}
+
+		if conditionType == "InstallPlanCompliant" {
+			if conditionReason == "InstallPlanRequiresApproval" || conditionReason == "InstallPlanApproved" {
+				upgradeAvailable = true
+			} else {
+				upgradeAvailable = false
+			}
+		} else if conditionType == "DeploymentCompliant" {
+			if conditionReason == "DeploymentsAvailable" {
+				deploymentAvailable = true
+			} else {
+				deploymentAvailable = false
+			}
+		}
+	}
+
+	node.Properties["deploymentAvailable"] = deploymentAvailable
+	node.Properties["upgradeAvailable"] = upgradeAvailable
+
 	return &PolicyResource{node: node}
 }
 
@@ -47,6 +138,6 @@ func (p PolicyResource) BuildNode() Node {
 
 // BuildEdges construct the edges for Policy Resources
 func (p PolicyResource) BuildEdges(ns NodeStore) []Edge {
-	//no op for now to implement interface
+	// no op for now to implement interface
 	return []Edge{}
 }

--- a/pkg/transforms/policy_test.go
+++ b/pkg/transforms/policy_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	policy "github.com/stolostron/governance-policy-propagator/api/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestTransformPolicy(t *testing.T) {
@@ -25,4 +26,65 @@ func TestTransformPolicy(t *testing.T) {
 	AssertEqual("remediationAction", node.Properties["remediationAction"], "enforce", t)
 	AssertEqual("disabled", node.Properties["disabled"], false, t)
 	AssertEqual("numRules", node.Properties["numRules"], 1, t)
+}
+
+func TestTransformConfigPolicy(t *testing.T) {
+	var object map[string]interface{}
+	UnmarshalFile("configurationpolicy.json", &object, t)
+
+	unstructured := &unstructured.Unstructured{
+		Object: object,
+	}
+
+	configResource := StandalonePolicyResourceBuilder(unstructured)
+
+	node := configResource.BuildNode()
+
+	// Test only the fields that exist in policy - the common test will test the other bits
+	AssertEqual("compliant", node.Properties["compliant"], "NonCompliant", t)
+	AssertEqual("remediationAction", node.Properties["remediationAction"], "inform", t)
+	AssertEqual("severity", node.Properties["severity"], "low", t)
+	AssertEqual("disabled", node.Properties["disabled"], false, t)
+	AssertEqual("_isExternal", node.Properties["_isExternal"], true, t)
+}
+
+func TestTransformOperatorPolicy(t *testing.T) {
+	var object map[string]interface{}
+	UnmarshalFile("operatorpolicy.json", &object, t)
+
+	unstructured := &unstructured.Unstructured{
+		Object: object,
+	}
+
+	operatorResource := OperatorPolicyResourceBuilder(unstructured)
+
+	node := operatorResource.BuildNode()
+
+	// Test only the fields that exist in policy - the common test will test the other bits
+	AssertEqual("compliant", node.Properties["compliant"], "NonCompliant", t)
+	AssertEqual("remediationAction", node.Properties["remediationAction"], "inform", t)
+	AssertEqual("severity", node.Properties["severity"], "critical", t)
+	AssertEqual("deploymentAvailable", node.Properties["deploymentAvailable"], false, t)
+	AssertEqual("upgradeAvailable", node.Properties["upgradeAvailable"], true, t)
+	AssertEqual("disabled", node.Properties["disabled"], false, t)
+	AssertEqual("_isExternal", node.Properties["_isExternal"], false, t)
+}
+
+func TestTransformCertPolicy(t *testing.T) {
+	var object map[string]interface{}
+	UnmarshalFile("certpolicy.json", &object, t)
+
+	unstructured := &unstructured.Unstructured{
+		Object: object,
+	}
+
+	certResource := StandalonePolicyResourceBuilder(unstructured)
+
+	node := certResource.BuildNode()
+
+	// Test only the fields that exist in policy - the common test will test the other bits
+	AssertEqual("compliant", node.Properties["compliant"], "Compliant", t)
+	AssertEqual("severity", node.Properties["severity"], "low", t)
+	AssertEqual("disabled", node.Properties["disabled"], false, t)
+	AssertEqual("_isExternal", node.Properties["_isExternal"], true, t)
 }

--- a/test-data/certpolicy.json
+++ b/test-data/certpolicy.json
@@ -1,0 +1,53 @@
+{
+  "apiVersion": "policy.open-cluster-management.io/v1",
+  "kind": "CertificatePolicy",
+  "metadata": {
+    "creationTimestamp": "2024-08-15T19:21:44Z",
+    "generation": 1,
+    "labels": {
+      "cluster-name": "local-cluster",
+      "cluster-namespace": "local-cluster",
+      "policy.open-cluster-management.io/cluster-name": "local-cluster",
+      "policy.open-cluster-management.io/cluster-namespace": "local-cluster",
+      "policy.open-cluster-management.io/policy": "default.cert-policy-dd"
+    },
+    "managedFields": [
+      {
+        "apiVersion": "policy.open-cluster-management.io/v1",
+        "manager": "multicluster-operators-subscription"
+      }
+    ],
+    "name": "policy-certificate",
+    "namespace": "local-cluster",
+    "ownerReferences": [
+      {
+        "apiVersion": "policy.open-cluster-management.io/v1",
+        "blockOwnerDeletion": true,
+        "controller": true,
+        "kind": "Policy",
+        "name": "default.cert-policy-dd",
+        "uid": "3104a97d-c42a-43de-b8fa-b8579d9d06b3"
+      }
+    ],
+    "resourceVersion": "395036",
+    "uid": "2fc12fad-80d4-4545-b9d5-bc329f12f4d1"
+  },
+  "spec": {
+    "disabled": false,
+    "minimumDuration": "300h",
+    "namespaceSelector": {
+      "exclude": ["kube-*"],
+      "include": ["default"]
+    },
+    "remediationAction": "inform",
+    "severity": "low"
+  },
+  "status": {
+    "compliancyDetails": {
+      "default": {
+        "message": "Found 0 non compliant certificates in the namespace default.\n"
+      }
+    },
+    "compliant": "Compliant"
+  }
+}

--- a/test-data/configurationpolicy.json
+++ b/test-data/configurationpolicy.json
@@ -1,0 +1,83 @@
+{
+  "apiVersion": "policy.open-cluster-management.io/v1",
+  "kind": "ConfigurationPolicy",
+  "metadata": {
+    "uid": "config-uid-1",
+    "creationTimestamp": "2024-07-19T14:47:58Z",
+    "finalizers": ["policy.open-cluster-management.io/delete-related-objects"],
+    "generation": 1,
+    "annotations": {
+      "apps.open-cluster-management.io/hosting-subscription": "policies/demo-sub",
+      "kubectl.kubernetes.io/last-applied-configuration": "tiger"
+    },
+    "labels": {
+      "cluster-name": "local-cluster",
+      "cluster-namespace": "local-cluster",
+      "policy.open-cluster-management.io/cluster-name": "local-cluster",
+      "policy.open-cluster-management.io/cluster-namespace": "local-cluster",
+      "policy.open-cluster-management.io/policy": "default.dd"
+    },
+    "name": "policy-namespace",
+    "namespace": "local-cluster",
+    "managedFields": [
+      {
+        "apiVersion": "policy.open-cluster-management.io/v1beta1",
+        "fieldsType": "FieldsV1",
+        "manager": "argocd"
+      }
+    ]
+  },
+  "spec": {
+    "disabled": false,
+    "object-templates": [
+      {
+        "complianceType": "musthave",
+        "objectDefinition": {
+          "apiVersion": "v1",
+          "kind": "Namespace",
+          "metadata": {
+            "name": "hi"
+          }
+        },
+        "recreateOption": "None"
+      }
+    ],
+    "pruneObjectBehavior": "DeleteAll",
+    "remediationAction": "inform",
+    "severity": "low"
+  },
+  "status": {
+    "compliancyDetails": [
+      {
+        "Compliant": "NonCompliant",
+        "Validity": {},
+        "conditions": [
+          {
+            "lastTransitionTime": "2024-07-19T14:47:59Z",
+            "message": "namespaces [hi] not found",
+            "reason": "K8s does not have a `must have` object",
+            "status": "True",
+            "type": "violation"
+          }
+        ]
+      }
+    ],
+    "compliant": "NonCompliant",
+    "lastEvaluated": "2024-07-19T16:55:31Z",
+    "lastEvaluatedGeneration": 1,
+    "relatedObjects": [
+      {
+        "compliant": "NonCompliant",
+        "object": {
+          "apiVersion": "v1",
+          "kind": "Namespace",
+          "metadata": {
+            "name": "hi"
+          }
+        },
+        "reason": "Resource not found but should exist",
+        "cluster": "local-cluster"
+      }
+    ]
+  }
+}

--- a/test-data/operatorpolicy.json
+++ b/test-data/operatorpolicy.json
@@ -1,0 +1,226 @@
+{
+  "apiVersion": "policy.open-cluster-management.io/v1beta1",
+  "kind": "OperatorPolicy",
+  "metadata": {
+    "creationTimestamp": "2024-08-15T16:58:38Z",
+    "generation": 1,
+    "annotations": { "apps.open-cluster-management.io/hosting-subscription": "policies/demo-sub" },
+    "labels": {
+      "cluster-name": "local-cluster",
+      "cluster-namespace": "local-cluster",
+      "policy.open-cluster-management.io/cluster-name": "local-cluster",
+      "policy.open-cluster-management.io/cluster-namespace": "local-cluster",
+      "policy.open-cluster-management.io/policy": "default.dd-operator"
+    },
+    "managedFields": [
+      {
+        "fieldsType": "FieldsV1",
+        "manager": "config-policy-controller"
+      }
+    ],
+    "name": "install-operator",
+    "namespace": "local-cluster",
+    "ownerReferences": [
+      {
+        "apiVersion": "policy.open-cluster-management.io/v1",
+        "blockOwnerDeletion": true,
+        "controller": true,
+        "kind": "Policy",
+        "name": "default.dd-operator",
+        "uid": "157a2f9c-8329-4377-99a8-544673e63cc7"
+      }
+    ],
+    "resourceVersion": "273745",
+    "uid": "2d0732a5-15b1-4631-9b8d-032f067b98d2"
+  },
+  "spec": {
+    "disabled": false,
+    "complianceConfig": {
+      "catalogSourceUnhealthy": "Compliant",
+      "deploymentsUnavailable": "NonCompliant",
+      "upgradesAvailable": "Compliant"
+    },
+    "complianceType": "musthave",
+    "remediationAction": "inform",
+    "removalBehavior": {
+      "clusterServiceVersions": "Delete",
+      "customResourceDefinitions": "Keep",
+      "operatorGroups": "DeleteIfUnused",
+      "subscriptions": "Delete"
+    },
+    "severity": "critical",
+    "subscription": {
+      "channel": "stable",
+      "name": "gatekeeper-operator-product",
+      "namespace": "openshift-operators",
+      "source": "redhat-operators",
+      "sourceNamespace": "openshift-marketplace",
+      "startingCSV": "v3.15.0"
+    },
+    "upgradeApproval": "Automatic"
+  },
+  "status": {
+    "compliant": "NonCompliant",
+    "conditions": [
+      {
+        "lastTransitionTime": "2024-08-15T16:58:38Z",
+        "message": "CatalogSource was found",
+        "reason": "CatalogSourcesFound",
+        "status": "False",
+        "type": "CatalogSourcesUnhealthy"
+      },
+      {
+        "lastTransitionTime": "2024-08-15T16:58:38Z",
+        "message": "the ClusterServiceVersion required by the policy was not found",
+        "reason": "ClusterServiceVersionMissing",
+        "status": "False",
+        "type": "ClusterServiceVersionCompliant"
+      },
+      {
+        "lastTransitionTime": "2024-08-15T16:58:38Z",
+        "message": "NonCompliant; the policy spec is valid, the policy does not specify an OperatorGroup but one already exists in the namespace - assuming that OperatorGroup is correct, the Subscription required by the policy was not found, there are no relevant InstallPlans in the namespace, the ClusterServiceVersion required by the policy was not found, no CRDs were found for the operator, there are no relevant deployments because the ClusterServiceVersion is missing, CatalogSource was found",
+        "reason": "NonCompliant",
+        "status": "False",
+        "type": "Compliant"
+      },
+      {
+        "lastTransitionTime": "2024-08-15T16:58:38Z",
+        "message": "no CRDs were found for the operator",
+        "reason": "RelevantCRDNotFound",
+        "status": "True",
+        "type": "CustomResourceDefinitionCompliant"
+      },
+      {
+        "lastTransitionTime": "2024-08-15T16:58:38Z",
+        "message": "there are no relevant deployments because the ClusterServiceVersion is missing",
+        "reason": "NoRelevantDeployments",
+        "status": "True",
+        "type": "DeploymentCompliant"
+      },
+      {
+        "lastTransitionTime": "2024-08-15T16:58:38Z",
+        "message": "an InstallPlan to update to [strimzi-cluster-operator.v0.36.0] is available",
+        "reason": "InstallPlanRequiresApproval",
+        "status": "True",
+        "type": "InstallPlanCompliant"
+      },
+      {
+        "lastTransitionTime": "2024-08-15T16:58:38Z",
+        "message": "the policy does not specify an OperatorGroup but one already exists in the namespace - assuming that OperatorGroup is correct",
+        "reason": "PreexistingOperatorGroupFound",
+        "status": "True",
+        "type": "OperatorGroupCompliant"
+      },
+      {
+        "lastTransitionTime": "2024-08-15T16:58:38Z",
+        "message": "the Subscription required by the policy was not found",
+        "reason": "SubscriptionMissing",
+        "status": "False",
+        "type": "SubscriptionCompliant"
+      },
+      {
+        "lastTransitionTime": "2024-08-15T16:58:38Z",
+        "message": "the policy spec is valid",
+        "reason": "PolicyValidated",
+        "status": "True",
+        "type": "ValidPolicySpec"
+      }
+    ],
+    "observedGeneration": 1,
+    "relatedObjects": [
+      {
+        "compliant": "Compliant",
+        "object": {
+          "apiVersion": "operators.coreos.com/v1alpha1",
+          "kind": "CatalogSource",
+          "metadata": {
+            "name": "redhat-operators",
+            "namespace": "openshift-marketplace"
+          }
+        },
+        "reason": "Resource found as expected",
+        "cluster": "local-cluster"
+      },
+      {
+        "compliant": "NonCompliant",
+        "object": {
+          "apiVersion": "operators.coreos.com/v1alpha1",
+          "kind": "ClusterServiceVersion",
+          "metadata": {
+            "name": "gatekeeper-operator-product",
+            "namespace": "openshift-operators"
+          }
+        },
+        "reason": "Resource not found but should exist",
+        "cluster": "local-cluster"
+      },
+      {
+        "compliant": "UnknownCompliancy",
+        "object": {
+          "apiVersion": "apiextensions.k8s.io/v1",
+          "kind": "CustomResourceDefinition",
+          "metadata": {
+            "name": "-"
+          }
+        },
+        "reason": "No relevant CustomResourceDefinitions found",
+        "cluster": "local-cluster"
+      },
+      {
+        "compliant": "UnknownCompliancy",
+        "object": {
+          "apiVersion": "apps/v1",
+          "kind": "Deployment",
+          "metadata": {
+            "name": "-"
+          }
+        },
+        "reason": "No relevant deployments found",
+        "cluster": "local-cluster"
+      },
+      {
+        "compliant": "Compliant",
+        "object": {
+          "apiVersion": "operators.coreos.com/v1alpha1",
+          "kind": "InstallPlan",
+          "metadata": {
+            "name": "-",
+            "namespace": "openshift-operators"
+          }
+        },
+        "reason": "There are no relevant InstallPlans in this namespace",
+        "cluster": "local-cluster"
+      },
+      {
+        "compliant": "Compliant",
+        "object": {
+          "apiVersion": "operators.coreos.com/v1",
+          "kind": "OperatorGroup",
+          "metadata": {
+            "name": "global-operators",
+            "namespace": "openshift-operators"
+          }
+        },
+        "properties": {
+          "uid": "7c60436b-6d6b-44a6-a534-2fd01967ade6"
+        },
+        "reason": "Resource found as expected",
+        "cluster": "local-cluster"
+      },
+      {
+        "compliant": "NonCompliant",
+        "object": {
+          "apiVersion": "operators.coreos.com/v1alpha1",
+          "kind": "Subscription",
+          "metadata": {
+            "name": "gatekeeper-operator-product",
+            "namespace": "openshift-operators"
+          }
+        },
+        "reason": "Resource not found but should exist",
+        "cluster": "local-cluster"
+      }
+    ],
+    "resolvedSubscriptionLabel": "gatekeeper-operator-product.openshift-operators"
+  }
+}


### PR DESCRIPTION

Ref: 
Signed-off-by: yiraeChristineKim <yikim@redhat.com>

### Related Issue
https://issues.redhat.com/browse/ACM-13031

### Description of changes
Add properties such as responseAction, compliant, annotations, severity, parentPolicyName, and parentPolicyNs to config/operator/cert policy. 

Common properties:
- managedFields
- annotations
- compliant
- responseAction (Cert won't have this pe)
- severity
- parentPolicyName/parentPolicyNs

OperatorPolicy
- upgradeAvailable
- deploymentAvailable
