### PR TITLE
Use a more generic type for detecting the API group

### DIFF
--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -34,17 +34,12 @@ type NodeStore struct {
 func commonAnnotations(object v1.Object) map[string]string {
 	// If CollectAnnotations is not true, then only collect annotations for allow listed resources.
 	if !config.Cfg.CollectAnnotations {
-		typeInfo, ok := object.(v1.Type)
+		objKind, ok := object.(schema.ObjectKind)
 		if !ok {
 			return nil
 		}
 
-		gv, err := schema.ParseGroupVersion(typeInfo.GetAPIVersion())
-		if err != nil {
-			return nil
-		}
-
-		switch gv.Group {
+		switch objKind.GroupVersionKind().Group {
 		case POLICY_OPEN_CLUSTER_MANAGEMENT_IO:
 		case "constraints.gatekeeper.sh":
 		default:

--- a/pkg/transforms/policy_test.go
+++ b/pkg/transforms/policy_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	policy "github.com/stolostron/governance-policy-propagator/api/v1"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -26,6 +27,7 @@ func TestTransformPolicy(t *testing.T) {
 	AssertEqual("remediationAction", node.Properties["remediationAction"], "enforce", t)
 	AssertEqual("disabled", node.Properties["disabled"], false, t)
 	AssertEqual("numRules", node.Properties["numRules"], 1, t)
+	assert.Len(t, node.Properties["annotation"], 3, "expected 3 annotations on the policy")
 }
 
 func TestTransformConfigPolicy(t *testing.T) {


### PR DESCRIPTION
The previous solution worked for unstructured and default types but not for the Policy kind. This new type works for all.