### PR TITLE
ACM-14658 Collect desired state of VirtualMachine

### DIFF
--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -64,17 +64,19 @@ var defaultTransformConfig = map[string]ResourceConfig{
 		properties: []ExtractProperty{
 			{Name: "cpu", JSONPath: `{.spec.template.spec.domain.cpu.cores}`},
 			{Name: "memory", JSONPath: `{.spec.template.spec.domain.memory.guest}`},
-			{Name: "status", JSONPath: `{.status.printableStatus}`},
 			{Name: "ready", JSONPath: `{.status.conditions[?(@.type=='Ready')].status}`},
+			{Name: "status", JSONPath: `{.status.printableStatus}`},
+			{Name: "_specRunning", JSONPath: `{.spec.running}`},
+			{Name: "_specRunStrategy", JSONPath: `{.spec.runStrategy}`},
 		},
 	},
 	"VirtualMachineInstance.kubevirt.io": {
 		properties: []ExtractProperty{
-			{Name: "node", JSONPath: `{.status.nodeName}`},
 			{Name: "ipaddress", JSONPath: `{.status.interfaces[0].ipAddress}`},
+			{Name: "liveMigratable", JSONPath: `{.status.conditions[?(@.type=='LiveMigratable')].status}`},
+			{Name: "node", JSONPath: `{.status.nodeName}`},
 			{Name: "phase", JSONPath: `{.status.phase}`},
 			{Name: "ready", JSONPath: `{.status.conditions[?(@.type=='Ready')].status}`},
-			{Name: "liveMigratable", JSONPath: `{.status.conditions[?(@.type=='LiveMigratable')].status}`},
 		},
 	},
 }

--- a/pkg/transforms/genericResource_test.go
+++ b/pkg/transforms/genericResource_test.go
@@ -96,11 +96,12 @@ func Test_genericResourceFromConfigVM(t *testing.T) {
 	AssertEqual("created", node.Properties["created"], "2024-04-30T16:22:02Z", t)
 
 	// Verify properties defined in the transform config
-	AssertEqual("display", node.Properties["status"], "Running", t)
-	AssertEqual("phase", node.Properties["ready"], "True", t)
 	AssertEqual("cpu", node.Properties["cpu"], int64(1), t)
 	AssertEqual("memory", node.Properties["memory"], "2Gi", t)
-
+	AssertEqual("ready", node.Properties["ready"], "True", t)
+	AssertEqual("status", node.Properties["status"], "Running", t)
+	AssertEqual("_specRunning", node.Properties["_specRunning"], true, t)
+	AssertEqual("_specRunStrategy", node.Properties["_specRunStrategy"], nil, t)
 }
 
 func Test_genericResourceFromConfigVMI(t *testing.T) {
@@ -115,11 +116,12 @@ func Test_genericResourceFromConfigVMI(t *testing.T) {
 	AssertEqual("created", node.Properties["created"], "2024-09-18T19:43:53Z", t)
 
 	// Verify properties defined in the transform config
-	AssertEqual("node", node.Properties["node"], "sno-0-0", t)
 	AssertEqual("ipaddress", node.Properties["ipaddress"], "10.128.1.193", t)
+	AssertEqual("liveMigratable", node.Properties["liveMigratable"], "False", t)
+	AssertEqual("node", node.Properties["node"], "sno-0-0", t)
 	AssertEqual("phase", node.Properties["phase"], "Running", t)
 	AssertEqual("ready", node.Properties["ready"], "True", t)
-	AssertEqual("liveMigratable", node.Properties["liveMigratable"], "False", t)
+
 }
 
 func Test_genericResourceFromConfigDataVolume(t *testing.T) {


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-14658

### Description of changes
- Collect desired state of Virtual Machine. (spec.running and spec.runStrategy)
- Using the names _specRunning and _specRunStrategy to indicate that this can change. Ideally we should combine these into a single field.
