### PR TITLE
Add edges for VAP and VAPB

### DIFF
--- a/pkg/transforms/vapbinding.go
+++ b/pkg/transforms/vapbinding.go
@@ -51,6 +51,20 @@ func (v VapBindingResource) BuildNode() Node {
 
 // BuildEdges construct the edges for VapBindingResource
 func (v VapBindingResource) BuildEdges(ns NodeStore) []Edge {
-	// no op for now to implement interface
-	return []Edge{}
+	policyName, ok := v.node.Properties["policyName"].(string)
+	if !ok {
+		return []Edge{}
+	}
+
+	nodeInfo := NodeInfo{
+		Name:      v.node.Properties["name"].(string),
+		NameSpace: "_NONE",
+		UID:       v.node.UID,
+		EdgeType:  "attachedTo",
+		Kind:      v.node.Properties["kind"].(string),
+	}
+
+	propSet := map[string]struct{}{policyName: {}}
+
+	return edgesByDestinationName(propSet, "ValidatingAdmissionPolicy", nodeInfo, ns, []string{})
 }

--- a/pkg/transforms/vapbinding_test.go
+++ b/pkg/transforms/vapbinding_test.go
@@ -21,3 +21,38 @@ func TestVapBinding(t *testing.T) {
 	AssertEqual("_ownedByGatekeeper", node.Properties["_ownedByGatekeeper"], true, t)
 	AssertEqual("policyName", node.Properties["policyName"], "demo-policy.example.com", t)
 }
+
+func TestVapBindingEdges(t *testing.T) {
+	var object map[string]interface{}
+	UnmarshalFile("vapbinding.json", &object, t)
+
+	vap := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "admissionregistration.k8s.io/v1",
+			"kind":       "ValidatingAdmissionPolicy",
+			"metadata": map[string]interface{}{
+				"name": "demo-policy.example.com",
+				"uid":  "7ed361c4-fa53-400c-8ae6-7ce6692012c3",
+			},
+		},
+	}
+	nodes := []Node{GenericResourceBuilder(vap).BuildNode()}
+	nodeStore := BuildFakeNodeStore(nodes)
+
+	vapb := &unstructured.Unstructured{Object: object}
+
+	edges := VapBindingResourceBuilder(vapb).BuildEdges(nodeStore)
+	if len(edges) != 1 {
+		t.Fatalf("Expected 1 edge but got %d", len(edges))
+	}
+
+	edge := edges[0]
+	expectedEdge := Edge{
+		EdgeType:   "attachedTo",
+		SourceUID:  "local-cluster/7385bbe4-031d-4cbe-833a-afd784526e6a",
+		DestUID:    "local-cluster/7ed361c4-fa53-400c-8ae6-7ce6692012c3",
+		SourceKind: "ValidatingAdmissionPolicyBinding",
+		DestKind:   "ValidatingAdmissionPolicy",
+	}
+	AssertDeepEqual("edge", edge, expectedEdge, t)
+}

--- a/test-data/vapbinding.json
+++ b/test-data/vapbinding.json
@@ -12,7 +12,8 @@
           "name": "all-must-have-owner",
           "uid": "dd427962-73e3-4484-8898-6b44ffe5256c"
         }
-      ]
+      ],
+      "uid": "7385bbe4-031d-4cbe-833a-afd784526e6a"
     },
     "spec": {
       "policyName": "demo-policy.example.com",


### PR DESCRIPTION
A ValidationAdmissionPolicyBinding now has an edge to its ValidatingAdmissionPolicy.