### PR TITLE
Add edges for VAP and VAPB

### DIFF
--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -378,8 +378,8 @@ func TestReconcilerComplete(t *testing.T) {
 	// Checks the count of nodes and edges based on the JSON files in pkg/test-data
 	// Update counts when the test data is changed
 	// We don't create Nodes for kind = Event
-	const Nodes = 43
-	const Edges = 51
+	const Nodes = 49
+	const Edges = 55
 	if len(com.Edges) != Edges || com.TotalEdges != Edges || len(com.Nodes) != Nodes || com.TotalNodes != Nodes {
 		ns := tr.NodeStore{
 			ByUID:               testReconciler.currentNodes,

--- a/pkg/transforms/common_test.go
+++ b/pkg/transforms/common_test.go
@@ -19,8 +19,10 @@ import (
 	machineryV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var labels = map[string]string{"app": "test", "fake": "true", "component": "testapp"}
-var timestamp = machineryV1.Now()
+var (
+	testLabels = map[string]string{"app": "test", "fake": "true", "component": "testapp"}
+	timestamp  = machineryV1.Now()
+)
 
 // Helper function for creating a k8s resource to pass in to tests.
 // In this case it's a pod.
@@ -32,7 +34,7 @@ func CreateGenericResource() machineryV1.Object {
 	p.Namespace = "default"
 	p.UID = "00aa0000-00aa-00a0-a000-00000a00a0a0"
 	p.CreationTimestamp = timestamp
-	p.Labels = labels
+	p.Labels = testLabels
 	p.Annotations = map[string]string{"hello": "world"}
 	return &p
 }
@@ -58,7 +60,7 @@ func TestCommonProperties(t *testing.T) {
 	noLabels := true
 	for key, value := range cp["label"].(map[string]string) {
 		noLabels = false
-		if labels[key] != value {
+		if testLabels[key] != value {
 			t.Error("Incorrect label: " + key)
 			t.Fail()
 		}

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -4,6 +4,8 @@ package transforms
 type ExtractProperty struct {
 	Name     string // `json:"name,omitempty"`
 	JSONPath string // `json:"jsonpath,omitempty"`
+	// An internal property to denote this property should be set on the node's metadata instead.
+	metadataOnly bool
 }
 
 // Declares the properties to extract from a given resource.
@@ -58,6 +60,12 @@ var defaultTransformConfig = map[string]ResourceConfig{
 		properties: []ExtractProperty{
 			{Name: "size", JSONPath: `{.spec.storage.resources.requests.storage}`},
 			{Name: "storageClassName", JSONPath: `{.spec.storage.storageClassName}`},
+		},
+	},
+	"ValidatingAdmissionPolicy.admissionregistration.k8s.io": {
+		properties: []ExtractProperty{
+			{Name: "paramKind_kind", JSONPath: `{.spec.paramKind.kind}`, metadataOnly: true},
+			{Name: "paramKind_apiVersion", JSONPath: `{.spec.paramKind.apiVersion}`, metadataOnly: true},
 		},
 	},
 	"VirtualMachine.kubevirt.io": {

--- a/pkg/transforms/genericresource.go
+++ b/pkg/transforms/genericresource.go
@@ -79,7 +79,21 @@ func GenericResourceBuilder(r *unstructured.Unstructured, additionalColumns ...E
 				}
 			}
 
-			n.Properties[prop.Name] = val
+			if prop.metadataOnly {
+				strVal, ok := val.(string)
+
+				if !ok {
+					klog.V(1).Infof(
+						"Unable to extract metadata prop [%s] from [%s.%s] Name: [%s] since it's not a string: %v",
+						prop.Name, kind, group, r.GetName(),
+					)
+					continue
+				}
+
+				n.Metadata[prop.Name] = strVal
+			} else {
+				n.Properties[prop.Name] = val
+			}
 		} else {
 			klog.Errorf("Unexpected error extracting [%s] from [%s.%s] Name: [%s]. Result object is empty.",
 				prop.Name, kind, group, r.GetName())

--- a/pkg/transforms/vapbinding.go
+++ b/pkg/transforms/vapbinding.go
@@ -3,25 +3,32 @@
 package transforms
 
 import (
+	"encoding/json"
 	"strings"
 
+	"github.com/golang/glog"
+	admissionregistration "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
 type VapBindingResource struct {
-	node Node
+	node     Node
+	paramRef *admissionregistration.ParamRef
 }
 
 // Validating admission policy Binding
 // Ref: https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/
 func VapBindingResourceBuilder(v *unstructured.Unstructured) *VapBindingResource {
-	node := transformCommon(v)         // Start off with the common properties
+	node := transformCommon(v) // Start off with the common properties
 
 	typeMeta := metav1.TypeMeta{
 		Kind:       v.GetKind(),
 		APIVersion: v.GetAPIVersion(),
 	}
-	
+
 	apiGroupVersion(typeMeta, &node) // add kind, apigroup and version
 	// Extract the properties specific to this type
 
@@ -41,7 +48,38 @@ func VapBindingResourceBuilder(v *unstructured.Unstructured) *VapBindingResource
 
 	node.Properties["_ownedByGatekeeper"] = fromGK
 
-	return &VapBindingResource{node: node}
+	binding := &VapBindingResource{node: node}
+
+	paramRefMap, ok, err := unstructured.NestedMap(v.Object, "spec", "paramRef")
+	if !ok {
+		return binding
+	}
+
+	if err != nil {
+		glog.Errorf("Failed to parse the ValidatingAdmissionPolicyBinding %s paramRef: %v", v.GetName(), err)
+
+		return binding
+	}
+
+	paramRefBytes, err := json.Marshal(paramRefMap)
+	if err != nil {
+		glog.Errorf("Failed to parse the ValidatingAdmissionPolicyBinding %s paramRef: %v", v.GetName(), err)
+
+		return binding
+	}
+
+	paramRef := &admissionregistration.ParamRef{}
+
+	err = json.Unmarshal(paramRefBytes, paramRef)
+	if err != nil {
+		glog.Errorf("Failed to parse the ValidatingAdmissionPolicyBinding %s paramRef: %v", v.GetName(), err)
+
+		return binding
+	}
+
+	binding.paramRef = paramRef
+
+	return binding
 }
 
 // BuildNode construct the node for VapBindingResource
@@ -51,6 +89,105 @@ func (v VapBindingResource) BuildNode() Node {
 
 // BuildEdges construct the edges for VapBindingResource
 func (v VapBindingResource) BuildEdges(ns NodeStore) []Edge {
-	// no op for now to implement interface
-	return []Edge{}
+	policyName, ok := v.node.Properties["policyName"].(string)
+	if !ok || policyName == "" {
+		return []Edge{}
+	}
+
+	nodeInfo := NodeInfo{
+		Name:      v.node.Properties["name"].(string),
+		NameSpace: "_NONE",
+		UID:       v.node.UID,
+		EdgeType:  "attachedTo",
+		Kind:      v.node.Properties["kind"].(string),
+	}
+
+	propSet := map[string]struct{}{policyName: {}}
+
+	edges := edgesByDestinationName(propSet, "ValidatingAdmissionPolicy", nodeInfo, ns, []string{})
+
+	if v.paramRef == nil {
+		return edges
+	}
+
+	policy, ok := ns.ByKindNamespaceName["ValidatingAdmissionPolicy"]["_NONE"][policyName]
+	if !ok {
+		return edges
+	}
+
+	paramKind := policy.Metadata["paramKind_kind"]
+	if paramKind == "" {
+		return edges
+	}
+
+	paramApiVersion := policy.Metadata["paramKind_apiVersion"]
+	if paramApiVersion == "" {
+		return edges
+	}
+
+	paramGV, err := schema.ParseGroupVersion(paramApiVersion)
+	if err != nil {
+		return edges
+	}
+
+	namespaceToName := ns.ByKindNamespaceName[paramKind]
+
+	if v.paramRef.Namespace != "" {
+		// If the namespace is specified, then limit the searches to just this namespace
+		namespaceToName = map[string]map[string]Node{
+			v.paramRef.Namespace: ns.ByKindNamespaceName[paramKind][v.paramRef.Namespace],
+		}
+	}
+
+	var paramRefSelector labels.Selector
+
+	if v.paramRef.Selector != nil {
+		var err error
+
+		paramRefSelector, err = metav1.LabelSelectorAsSelector(v.paramRef.Selector)
+		if err != nil {
+			return edges
+		}
+	}
+
+	for _, nodeMap := range namespaceToName {
+		for _, node := range nodeMap {
+			version, ok := node.Properties["apiversion"].(string)
+			if !ok || version != paramGV.Version {
+				continue
+			}
+
+			group, ok := node.Properties["apigroup"].(string)
+			if (!ok && group != "") || group != paramGV.Group {
+				continue
+			}
+
+			if v.paramRef.Name != "" && v.paramRef.Name != node.Properties["name"].(string) {
+				continue
+			}
+
+			if paramRefSelector != nil {
+				nodeLabels, ok := node.Properties["label"].(map[string]string)
+				if !ok {
+					continue
+				}
+
+				nodeLabelsSet := labels.Set(nodeLabels)
+
+				if !paramRefSelector.Matches(nodeLabelsSet) {
+					continue
+				}
+			}
+
+			edges = append(edges, Edge{
+				EdgeType:   "paramReferences",
+				SourceUID:  v.node.UID,
+				SourceKind: "ValidatingAdmissionPolicyBinding",
+				DestKind:   paramKind,
+				DestUID:    node.UID,
+			})
+		}
+	}
+
+	return edges
 }

--- a/pkg/transforms/vapbinding_test.go
+++ b/pkg/transforms/vapbinding_test.go
@@ -3,10 +3,12 @@
 package transforms
 
 import (
+	"sort"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
 func TestVapBinding(t *testing.T) {
 	var object map[string]interface{}
 	UnmarshalFile("vapbinding.json", &object, t)
@@ -20,4 +22,223 @@ func TestVapBinding(t *testing.T) {
 	AssertDeepEqual("validationActions", node.Properties["validationActions"], []string{"Deny", "Warn", "Audit"}, t)
 	AssertEqual("_ownedByGatekeeper", node.Properties["_ownedByGatekeeper"], true, t)
 	AssertEqual("policyName", node.Properties["policyName"], "demo-policy.example.com", t)
+}
+
+func TestVapBindingEdges(t *testing.T) {
+	var object map[string]interface{}
+	UnmarshalFile("vapbinding.json", &object, t)
+
+	vap := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "admissionregistration.k8s.io/v1",
+			"kind":       "ValidatingAdmissionPolicy",
+			"metadata": map[string]interface{}{
+				"name": "demo-policy.example.com",
+				"uid":  "7ed361c4-fa53-400c-8ae6-7ce6692012c3",
+			},
+		},
+	}
+	nodes := []Node{GenericResourceBuilder(vap).BuildNode()}
+	nodeStore := BuildFakeNodeStore(nodes)
+
+	vapb := &unstructured.Unstructured{Object: object}
+
+	edges := VapBindingResourceBuilder(vapb).BuildEdges(nodeStore)
+	if len(edges) != 1 {
+		t.Fatalf("Expected 1 edge but got %d", len(edges))
+	}
+
+	edge := edges[0]
+	expectedEdge := Edge{
+		EdgeType:   "attachedTo",
+		SourceUID:  "local-cluster/7385bbe4-031d-4cbe-833a-afd784526e6a",
+		DestUID:    "local-cluster/7ed361c4-fa53-400c-8ae6-7ce6692012c3",
+		SourceKind: "ValidatingAdmissionPolicyBinding",
+		DestKind:   "ValidatingAdmissionPolicy",
+	}
+	AssertDeepEqual("edge", edge, expectedEdge, t)
+}
+
+func TestVapBindingEdgesGatekeeper(t *testing.T) {
+	vapb := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	UnmarshalFile("vapb-gatekeeper.json", &vapb.Object, t)
+
+	vap := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	UnmarshalFile("vap-gatekeeper.json", &vap.Object, t)
+
+	constraint := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	UnmarshalFile("vap-gatekeeper-constraint.json", &constraint.Object, t)
+
+	nodes := []Node{
+		VapBindingResourceBuilder(vapb).BuildNode(),
+		GenericResourceBuilder(vap).BuildNode(),
+		GenericResourceBuilder(constraint).BuildNode(),
+	}
+	nodeStore := BuildFakeNodeStore(nodes)
+
+	edges := VapBindingResourceBuilder(vapb).BuildEdges(nodeStore)
+	if len(edges) != 3 {
+		t.Fatalf("Expected 3 edges but got %d", len(edges))
+	}
+
+	edge := edges[0]
+	expectedEdge := Edge{
+		EdgeType:   "attachedTo",
+		SourceUID:  "local-cluster/13e52147-2d8a-44ec-ab1a-11be247d4816",
+		DestUID:    "local-cluster/3d21ea2d-3582-4aa8-85ff-f8dd83382b4d",
+		SourceKind: "ValidatingAdmissionPolicyBinding",
+		DestKind:   "ValidatingAdmissionPolicy",
+	}
+	AssertDeepEqual("edge", edge, expectedEdge, t)
+
+	edge2 := edges[1]
+	expectedEdge2 := Edge{
+		EdgeType:   "uses",
+		SourceUID:  "local-cluster/903d9fea-540a-4805-9ed2-f4e15e57f0ea",
+		DestUID:    "local-cluster/3d21ea2d-3582-4aa8-85ff-f8dd83382b4d",
+		SourceKind: "K8sRequiredLabels",
+		DestKind:   "ValidatingAdmissionPolicy",
+	}
+	AssertDeepEqual("edge", edge2, expectedEdge2, t)
+
+	edge3 := edges[2]
+	expectedEdge3 := Edge{
+		EdgeType:   "paramReferences",
+		SourceUID:  "local-cluster/13e52147-2d8a-44ec-ab1a-11be247d4816",
+		DestUID:    "local-cluster/903d9fea-540a-4805-9ed2-f4e15e57f0ea",
+		SourceKind: "ValidatingAdmissionPolicyBinding",
+		DestKind:   "K8sRequiredLabels",
+	}
+	AssertDeepEqual("edge", edge3, expectedEdge3, t)
+}
+
+func TestVapBindingEdgesSelector(t *testing.T) {
+	vapb := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	UnmarshalFile("vapb-selector.json", &vapb.Object, t)
+
+	vap := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	UnmarshalFile("vap-selector.json", &vap.Object, t)
+
+	configMap1 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "configmap1",
+				"namespace": "policies-configs",
+				"uid":       "a370cb76-a97c-4d9f-9249-c9bd8c2e4415",
+				"labels": map[string]interface{}{
+					"vap-config": "max-replicas",
+					"random":     "configmap1",
+				},
+			},
+			"data": map[string]interface{}{
+				"maxReplicas.maxReplicas": "5",
+			},
+		},
+	}
+
+	configMap2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "configmap2",
+				"namespace": "policies-configs",
+				"uid":       "9768ff35-6d4c-4329-b3d6-b2929ab6d277",
+				"labels": map[string]interface{}{
+					"vap-config": "max-replicas",
+					"random":     "configmap2",
+				},
+			},
+			"data": map[string]interface{}{
+				"maxReplicas.maxReplicas": "3",
+			},
+		},
+	}
+
+	configMapNoLabel := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "configmap-no-label",
+				"namespace": "policies-configs",
+				"uid":       "9ce38d78-3398-4226-9134-b31eb0bc30bc",
+				"labels": map[string]interface{}{
+					"random": "configmap-no-label",
+				},
+			},
+			"data": map[string]interface{}{
+				"maxReplicas.maxReplicas": "2",
+			},
+		},
+	}
+
+	configMapWrongNamespace := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "configmap-wrong-namespace",
+				"namespace": "random-namespace",
+				"uid":       "efdc566a-a1f8-4c9c-ab8a-4f8c9fc4b085",
+				"labels": map[string]interface{}{
+					"vap-config": "max-replicas",
+					"random":     "config-wrong-namespace",
+				},
+			},
+			"data": map[string]interface{}{
+				"maxReplicas.maxReplicas": "16",
+			},
+		},
+	}
+
+	nodes := []Node{
+		VapBindingResourceBuilder(vapb).BuildNode(),
+		GenericResourceBuilder(vap).BuildNode(),
+		GenericResourceBuilder(configMap1).BuildNode(),
+		GenericResourceBuilder(configMap2).BuildNode(),
+		GenericResourceBuilder(configMapNoLabel).BuildNode(),
+		GenericResourceBuilder(configMapWrongNamespace).BuildNode(),
+	}
+	nodeStore := BuildFakeNodeStore(nodes)
+
+	edges := VapBindingResourceBuilder(vapb).BuildEdges(nodeStore)
+	if len(edges) != 3 {
+		t.Fatalf("Expected 3 edges but got %d", len(edges))
+	}
+
+	// Sort the edges so the order is consistent for the assertions below
+	sort.Slice(edges, func(i, j int) bool { return edges[i].DestUID < edges[j].DestUID })
+
+	edge := edges[0]
+	expectedEdge := Edge{
+		EdgeType:   "attachedTo",
+		SourceUID:  "local-cluster/8b0cfdca-27c0-48cb-a5be-bd376786498a",
+		DestUID:    "local-cluster/2a13d661-9ea4-4ddd-9ca6-2a0fea714072",
+		SourceKind: "ValidatingAdmissionPolicyBinding",
+		DestKind:   "ValidatingAdmissionPolicy",
+	}
+	AssertDeepEqual("edge", edge, expectedEdge, t)
+
+	edge2 := edges[1]
+	expectedEdge2 := Edge{
+		EdgeType:   "paramReferences",
+		SourceUID:  "local-cluster/8b0cfdca-27c0-48cb-a5be-bd376786498a",
+		DestUID:    "local-cluster/9768ff35-6d4c-4329-b3d6-b2929ab6d277",
+		SourceKind: "ValidatingAdmissionPolicyBinding",
+		DestKind:   "ConfigMap",
+	}
+	AssertDeepEqual("edge", edge2, expectedEdge2, t)
+
+	edge3 := edges[2]
+	expectedEdge3 := Edge{
+		EdgeType:   "paramReferences",
+		SourceUID:  "local-cluster/8b0cfdca-27c0-48cb-a5be-bd376786498a",
+		DestUID:    "local-cluster/a370cb76-a97c-4d9f-9249-c9bd8c2e4415",
+		SourceKind: "ValidatingAdmissionPolicyBinding",
+		DestKind:   "ConfigMap",
+	}
+	AssertDeepEqual("edge", edge3, expectedEdge3, t)
 }

--- a/test-data/vap-gatekeeper-constraint.json
+++ b/test-data/vap-gatekeeper-constraint.json
@@ -1,0 +1,44 @@
+{
+    "apiVersion": "constraints.gatekeeper.sh/v1beta1",
+    "kind": "K8sRequiredLabels",
+    "metadata": {
+        "creationTimestamp": "2024-10-29T13:53:27Z",
+        "generation": 1,
+        "name": "all-must-have-owner",
+        "resourceVersion": "463348",
+        "uid": "903d9fea-540a-4805-9ed2-f4e15e57f0ea"
+    },
+    "spec": {
+        "enforcementAction": "deny",
+        "match": {
+            "kinds": [
+                {
+                    "apiGroups": [
+                        "v1"
+                    ],
+                    "kinds": [
+                        "Pod"
+                    ]
+                }
+            ],
+            "namespaces": [
+                "dd"
+            ]
+        },
+        "parameters": {
+            "labels": [
+                {
+                    "key": "banana"
+                },
+                {
+                    "key": "apple"
+                }
+            ],
+            "message": "fruits are needed"
+        }
+    },
+    "status": {
+        "auditTimestamp": "2024-10-29T15:14:03Z",
+        "totalViolations": 0
+    }
+}

--- a/test-data/vap-gatekeeper.json
+++ b/test-data/vap-gatekeeper.json
@@ -1,0 +1,93 @@
+{
+    "apiVersion": "admissionregistration.k8s.io/v1",
+    "kind": "ValidatingAdmissionPolicy",
+    "metadata": {
+        "creationTimestamp": "2024-10-29T13:53:21Z",
+        "generation": 1,
+        "name": "gatekeeper-k8srequiredlabels",
+        "ownerReferences": [
+            {
+                "apiVersion": "templates.gatekeeper.sh/v1beta1",
+                "blockOwnerDeletion": true,
+                "controller": true,
+                "kind": "ConstraintTemplate",
+                "name": "k8srequiredlabels",
+                "uid": "cad04d17-def3-4974-a880-c1a0701be9b7"
+            }
+        ],
+        "resourceVersion": "127075",
+        "uid": "3d21ea2d-3582-4aa8-85ff-f8dd83382b4d"
+    },
+    "spec": {
+        "failurePolicy": "Ignore",
+        "matchConditions": [
+            {
+                "expression": "\n\t!has(params.spec) ? true: (\n\t\t!has(params.spec.match) ? true: (\n\t\t\t!has(params.spec.match.excludedNamespaces) ? true : (\n\t\t\t\t[object, oldObject].exists(obj,\n\t\t\t\t\tobj != null \u0026\u0026 (\n\t\t\t\t\t\t// cluster-scoped objects always match\n\t\t\t\t\t\t!has(obj.metadata.namespace) || obj.metadata.namespace == \"\" ? true : (\n\t\t\t\t\t\t\t!params.spec.match.excludedNamespaces.exists(nsMatcher,\n\t\t\t\t\t\t\t\t(string(obj.metadata.namespace).matches(\"^\" + string(nsMatcher).replace(\"*\", \".*\") + \"$\"))\n\t\t\t\t\t\t\t)\n\t\t\t\t\t\t)\n\t\t\t\t\t)\n\t\t\t\t)\n\t\t\t)\n\t\t)\n\t)\n\t",
+                "name": "gatekeeper_internal_match_excluded_namespaces"
+            },
+            {
+                "expression": "\n\t!has(params.spec) ? true: (\n\t\t!has(params.spec.match) ? true: (\n\t\t\t!has(params.spec.match.namespaces) ? true : (\n\t\t\t\t[object, oldObject].exists(obj,\n\t\t\t\t\tobj != null \u0026\u0026 (\n\t\t\t\t\t\t// cluster-scoped objects always match\n\t\t\t\t\t\t!has(obj.metadata.namespace) || obj.metadata.namespace == \"\" ? true : (\n\t\t\t\t\t\t\tparams.spec.match.namespaces.exists(nsMatcher,\n\t\t\t\t\t\t\t\t(string(obj.metadata.namespace).matches(\"^\" + string(nsMatcher).replace(\"*\", \".*\") + \"$\"))\n\t\t\t\t\t\t\t)\n\t\t\t\t\t\t)\n\t\t\t\t\t)\n\t\t\t\t)\n\t\t\t)\n\t\t)\n\t)\n\t",
+                "name": "gatekeeper_internal_match_namespaces"
+            },
+            {
+                "expression": "\n\t!has(params.spec) ? true: (\n\t\t!has(params.spec.match) ? true: (\n\t\t\t!has(params.spec.match.name) ? true : (\n\t\t\t\t[object, oldObject].exists(obj,\n\t\t\t\t\tobj != null \u0026\u0026 (\n\t\t\t\t\t\t(has(obj.metadata.generateName) \u0026\u0026 obj.metadata.generateName != \"\" \u0026\u0026 params.spec.match.name.endsWith(\"*\") \u0026\u0026 string(obj.metadata.generateName).matches(\"^\" + string(params.spec.match.name).replace(\"*\", \".*\") + \"$\")) ||\n\t\t\t\t\t\t(has(obj.metadata.name) \u0026\u0026 string(obj.metadata.name).matches(\"^\" + string(params.spec.match.name).replace(\"*\", \".*\") + \"$\"))\n\t\t\t\t\t)\n\t\t\t\t)\n\t\t\t)\n\t\t)\n\t)\n\t",
+                "name": "gatekeeper_internal_match_name"
+            },
+            {
+                "expression": "\n\t!has(params.spec) ? true: (\n\t\t!has(params.spec.match) ? true: (\n\t\t\t!has(params.spec.match.kinds) ? true : (\n\t\t\t\tparams.spec.match.kinds.exists(groupskinds,\n\t\t\t\t\t(!has(groupskinds.kinds) || size(groupskinds.kinds) == 0 || \"*\" in groupskinds.kinds || request.kind.kind in groupskinds.kinds) \u0026\u0026\n\t\t\t\t\t(!has(groupskinds.apiGroups) || size(groupskinds.apiGroups) == 0 || \"*\" in groupskinds.apiGroups || request.kind.group in groupskinds.apiGroups)\n\t\t\t\t)\n\t\t\t)\n\t\t)\n\t)\n\t",
+                "name": "gatekeeper_internal_match_kinds"
+            }
+        ],
+        "matchConstraints": {
+            "matchPolicy": "Equivalent",
+            "namespaceSelector": {},
+            "objectSelector": {},
+            "resourceRules": [
+                {
+                    "apiGroups": [
+                        "*"
+                    ],
+                    "apiVersions": [
+                        "*"
+                    ],
+                    "operations": [
+                        "CREATE",
+                        "UPDATE"
+                    ],
+                    "resources": [
+                        "*"
+                    ],
+                    "scope": "*"
+                }
+            ]
+        },
+        "paramKind": {
+            "apiVersion": "constraints.gatekeeper.sh/v1beta1",
+            "kind": "K8sRequiredLabels"
+        },
+        "validations": [
+            {
+                "expression": "[object, oldObject].exists(obj, obj != null \u0026\u0026 has(obj.metadata) \u0026\u0026 variables.params.labels.all(entry, has(obj.metadata.labels) \u0026\u0026 entry.key in obj.metadata.labels))",
+                "messageExpression": "\"missing required label, requires all of: \" + variables.params.labels.map(entry, entry.key).join(\", \") + \"  \" + variables.params.message"
+            },
+            {
+                "expression": "object.dd == null",
+                "messageExpression": "\"dd is null\""
+            }
+        ],
+        "variables": [
+            {
+                "expression": "has(request.operation) \u0026\u0026 request.operation == \"DELETE\" \u0026\u0026 object == null ? oldObject : object",
+                "name": "anyObject"
+            },
+            {
+                "expression": "!has(params.spec) ? null : !has(params.spec.parameters) ? null: params.spec.parameters",
+                "name": "params"
+            }
+        ]
+    },
+    "status": {
+        "observedGeneration": 1,
+        "typeChecking": {}
+    }
+}

--- a/test-data/vap-selector.json
+++ b/test-data/vap-selector.json
@@ -1,0 +1,49 @@
+{
+  "apiVersion": "admissionregistration.k8s.io/v1",
+  "kind": "ValidatingAdmissionPolicy",
+  "metadata": {
+    "name": "max-replicas-deployments",
+    "uid": "2a13d661-9ea4-4ddd-9ca6-2a0fea714072"
+  },
+  "spec": {
+    "failurePolicy": "Fail",
+    "paramKind": {
+      "apiVersion": "v1",
+      "kind": "ConfigMap"
+    },
+    "matchConstraints": {
+      "resourceRules": [
+        {
+          "apiGroups": [
+            "apps"
+          ],
+          "apiVersions": [
+            "v1"
+          ],
+          "operations": [
+            "CREATE",
+            "UPDATE"
+          ],
+          "resources": [
+            "deployments"
+          ]
+        }
+      ]
+    },
+    "validations": [
+      {
+        "expression": "params != null",
+        "message": "params missing but required to bind to this policy"
+      },
+      {
+        "expression": "has(params.data.maxReplicas)",
+        "message": "params.data.maxReplicas missing but required to bind to this policy"
+      },
+      {
+        "expression": "object.spec.replicas <= int(params.data.maxReplicas)",
+        "messageExpression": "'object.spec.replicas must be no greater than ' + string(params.data.maxReplicas)",
+        "reason": "Invalid"
+      }
+    ]
+  }
+}

--- a/test-data/vapb-gatekeeper.json
+++ b/test-data/vapb-gatekeeper.json
@@ -1,0 +1,31 @@
+{
+    "apiVersion": "admissionregistration.k8s.io/v1",
+    "kind": "ValidatingAdmissionPolicyBinding",
+    "metadata": {
+        "creationTimestamp": "2024-10-29T13:53:47Z",
+        "generation": 1,
+        "name": "gatekeeper-all-must-have-owner",
+        "ownerReferences": [
+            {
+                "apiVersion": "constraints.gatekeeper.sh/v1beta1",
+                "blockOwnerDeletion": true,
+                "controller": true,
+                "kind": "K8sRequiredLabels",
+                "name": "all-must-have-owner",
+                "uid": "903d9fea-540a-4805-9ed2-f4e15e57f0ea"
+            }
+        ],
+        "resourceVersion": "127831",
+        "uid": "13e52147-2d8a-44ec-ab1a-11be247d4816"
+    },
+    "spec": {
+        "paramRef": {
+            "name": "all-must-have-owner",
+            "parameterNotFoundAction": "Allow"
+        },
+        "policyName": "gatekeeper-k8srequiredlabels",
+        "validationActions": [
+            "Deny"
+        ]
+    }
+}

--- a/test-data/vapb-selector.json
+++ b/test-data/vapb-selector.json
@@ -1,0 +1,23 @@
+{
+    "apiVersion": "admissionregistration.k8s.io/v1",
+    "kind": "ValidatingAdmissionPolicyBinding",
+    "metadata": {
+        "name": "max-replicas-deployments",
+        "uid": "8b0cfdca-27c0-48cb-a5be-bd376786498a"
+    },
+    "spec": {
+        "paramRef": {
+            "namespace": "policies-configs",
+            "selector": {
+                "matchLabels": {
+                    "vap-config": "max-replicas"
+                }
+            },
+            "parameterNotFoundAction": "Deny"
+        },
+        "policyName": "max-replicas-deployments",
+        "validationActions": [
+            "Deny"
+        ]
+    }
+}

--- a/test-data/vapbinding.json
+++ b/test-data/vapbinding.json
@@ -12,7 +12,8 @@
           "name": "all-must-have-owner",
           "uid": "dd427962-73e3-4484-8898-6b44ffe5256c"
         }
-      ]
+      ],
+      "uid": "7385bbe4-031d-4cbe-833a-afd784526e6a"
     },
     "spec": {
       "policyName": "demo-policy.example.com",


### PR DESCRIPTION
A ValidationAdmissionPolicyBinding now has an edge to its ValidatingAdmissionPolicy. Additionally, all paramRefs are also added as edges to the ValidationAdmissionPolicyBinding.

Relates:
https://issues.redhat.com/browse/ACM-15249