### PR TITLE
Add annotations to gatekeeper muation for severity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ output/
 build-harness/
 build-harness-extensions/
 search-collector
+.vscode/
 
 !vbh/.build-harness-vendorized
 !vbh/build-harness

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -41,7 +41,9 @@ func commonAnnotations(object v1.Object) map[string]string {
 
 		switch objKind.GroupVersionKind().Group {
 		case POLICY_OPEN_CLUSTER_MANAGEMENT_IO:
+		// Add annotations for severity
 		case "constraints.gatekeeper.sh":
+		case "mutations.gatekeeper.sh":
 		default:
 			return nil
 		}


### PR DESCRIPTION
- Add annotations to gatekeeper muation for severity to show on discovered policies
Signed-off-by: yiraeChristineKim <yikim@redhat.com>

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-16117 (bug)

### Description of changes
- Add annotations to gatekeeper muation for severity to show on discovered policies
