### PR TITLE
Update konflux schedule and don't run on PRs to main

### DIFF
--- a/.tekton/search-collector-acm-213-pull-request.yaml
+++ b/.tekton/search-collector-acm-213-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "release-2.13"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-acm-213

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "schedule": "* 0-8 1 * *",
+    "schedule": "before 8am on Tuesday",
     "timezone": "America/New_York"
 }


### PR DESCRIPTION
### Related Issue
N/A

### Description of changes
- Updates the konflux schedule to run every Tuesday. Current cron expression isn't working as expected.
- Don't run konflux job on PRs to main.
