### PR TITLE
ACM-17312 Reduce CPU by skipping edge rebuild when nothing has changed

### DIFF
--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -109,14 +109,14 @@ func NewReconciler() *Reconciler {
 // Returns the diff between the current and previous states, and resets the diff.
 // TODO the latter half of this function got pretty messy, it could use a refactor/rewrite
 func (r *Reconciler) Diff() Diff {
-	klog.V(4).Info("Reconciler calculating diff from previous state.")
+	klog.V(4).Info("Reconciler is calculating diff from previous state.")
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
 	ret := Diff{}
 
 	if len(r.diffNodes) == 0 {
-		klog.V(5).Info("Calculating diff... no events since the last reconcile.")
+		klog.V(5).Info("Reconciler has no events since the last reconcile.")
 		return ret
 	}
 
@@ -194,7 +194,7 @@ func (r *Reconciler) Diff() Diff {
 
 // Returns the complete current state and resets the diff
 func (r *Reconciler) Complete() CompleteState {
-	klog.V(3).Info("Reconciler is building complete state.")
+	klog.V(3).Info("Reconciler is building the complete state.")
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
@@ -263,7 +263,7 @@ func (r *Reconciler) allEdges() map[string]map[string]tr.Edge {
 
 	// Loop across all the nodes and build their edges.
 	for _, uid := range append(appUIDs, otherUIDs...) {
-		klog.V(5).Infof("Calculating edges UID: %s", uid)
+		klog.V(6).Infof("Calculating edges for node with UID: %s", uid)
 		edges := r.edgeFuncs[uid](ns) // Get edges from this specific node
 
 		edges = append(edges, tr.CommonEdges(uid, ns)...) // Get common edges for this node

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -15,10 +15,10 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/golang/glog"
 	lru "github.com/golang/groupcache/lru"
 	"github.com/stolostron/search-collector/pkg/metrics"
 	tr "github.com/stolostron/search-collector/pkg/transforms"
+	"k8s.io/klog/v2"
 )
 
 // Size of the LRU cache used to find out of order delete/add sequences
@@ -109,10 +109,16 @@ func NewReconciler() *Reconciler {
 // Returns the diff between the current and previous states, and resets the diff.
 // TODO the latter half of this function got pretty messy, it could use a refactor/rewrite
 func (r *Reconciler) Diff() Diff {
+	klog.V(4).Info("Reconciler calculating diff from previous state.")
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
 	ret := Diff{}
+
+	if len(r.diffNodes) == 0 {
+		klog.V(5).Info("Calculating diff... no events since the last reconcile.")
+		return ret
+	}
 
 	// Fill out nodes
 	for _, ne := range r.diffNodes {
@@ -188,6 +194,7 @@ func (r *Reconciler) Diff() Diff {
 
 // Returns the complete current state and resets the diff
 func (r *Reconciler) Complete() CompleteState {
+	klog.V(3).Info("Reconciler is building complete state.")
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
@@ -224,6 +231,7 @@ func (r *Reconciler) Complete() CompleteState {
 // Keyed by srcUID then destUID for fast comparison with previous.
 // This function reads from the state, locking left up to caller (complete and diff methods)
 func (r *Reconciler) allEdges() map[string]map[string]tr.Edge {
+	klog.V(4).Info("Reconciler is rebuilding edges for all nodes.")
 	ret := make(map[string]map[string]tr.Edge)
 
 	ns := tr.NodeStore{
@@ -255,7 +263,7 @@ func (r *Reconciler) allEdges() map[string]map[string]tr.Edge {
 
 	// Loop across all the nodes and build their edges.
 	for _, uid := range append(appUIDs, otherUIDs...) {
-		glog.V(5).Infof("Calculating edges UID: %s", uid)
+		klog.V(5).Infof("Calculating edges UID: %s", uid)
 		edges := r.edgeFuncs[uid](ns) // Get edges from this specific node
 
 		edges = append(edges, tr.CommonEdges(uid, ns)...) // Get common edges for this node
@@ -279,7 +287,7 @@ func (r *Reconciler) allEdges() map[string]map[string]tr.Edge {
 
 // This method takes a channel and constantly receives from it, reconciling the input with whatever is currently stored
 func (r *Reconciler) receive() {
-	glog.Info("Reconciler Routine Started")
+	klog.Info("Reconciler receive routine started.")
 	for {
 		r.reconcileNode()
 	}
@@ -363,7 +371,7 @@ func (r *Reconciler) reconcileNode() {
 			// If node has already been sent, check the previous helm revision is latest and discard current one
 			if inPrevious {
 				if previousNode.Properties["revision"].(int64) > ne.Node.Properties["revision"].(int64) {
-					glog.V(5).Infof("Skip %d for  release %s - previous is good",
+					klog.V(5).Infof("Skip %d for  release %s - previous is good",
 						ne.Node.Properties["revision"], ne.Node.Properties["name"])
 					return
 				}
@@ -371,7 +379,7 @@ func (r *Reconciler) reconcileNode() {
 			// If we have processed this release already (ready to send), check it's the latest and discard current one
 			if nodeVal, ok := r.currentNodes[ne.UID]; ok {
 				if nodeVal.Properties["revision"].(int64) > ne.Node.Properties["revision"].(int64) {
-					glog.V(5).Infof("Skip %d for  release %s - lower revision",
+					klog.V(5).Infof("Skip %d for  release %s - lower revision",
 						ne.Node.Properties["revision"], ne.Node.Properties["name"])
 					return
 				}


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-17312

### Description of changes
- Skip rebuild edges when nothing has changed
- CPU usage reduced by ~60% 
  - In the sample below cpu was reduced from a peak of 25m to 10m
- Slight memory reduction. The samples below show a larger gain, but it's not consistent.

### CPU usage before
![image](https://github.com/user-attachments/assets/54c2641f-44bc-4abc-97e9-4316027a0203)

### CPU usage after
![image](https://github.com/user-attachments/assets/9051c335-cd4e-48a5-9aad-3b582bfd6c65)

