### PR TITLE
ACM-16461 index more resources for kind node

### DIFF
--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -676,7 +676,7 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 				}
 
 				node.Metadata[prop.Name] = strVal
-			} else if prop.isMemory {
+			} else if prop.DataType == DataTypeBytes {
 				strVal, ok := val.(string)
 
 				if !ok {

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -4,6 +4,8 @@ package transforms
 type ExtractProperty struct {
 	Name     string // `json:"name,omitempty"`
 	JSONPath string // `json:"jsonpath,omitempty"`
+	// Denotes this property represents a memory field of a resource and must be converted to bytes for standardization
+	isMemory bool
 	// An internal property to denote this property should be set on the node's metadata instead.
 	metadataOnly bool
 }
@@ -61,8 +63,8 @@ var defaultTransformConfig = map[string]ResourceConfig{
 	"Node": {
 		properties: []ExtractProperty{
 			{Name: "ipAddress", JSONPath: `{.status.addresses[?(@.type=="InternalIP")].address}`},
-			{Name: "memoryAllocatable", JSONPath: `{.status.allocatable.memory}`},
-			{Name: "memoryCapacity", JSONPath: `{.status.capacity.memory}`},
+			{Name: "memoryAllocatable", JSONPath: `{.status.allocatable.memory}`, isMemory: true},
+			{Name: "memoryCapacity", JSONPath: `{.status.capacity.memory}`, isMemory: true},
 		},
 	},
 	"StorageClass.storage.k8s.io": {
@@ -93,7 +95,7 @@ var defaultTransformConfig = map[string]ResourceConfig{
 			{Name: "agentConnected", JSONPath: `{.status.conditions[?(@.type=="AgentConnected")].status}`},
 			{Name: "cpu", JSONPath: `{.spec.template.spec.domain.cpu.cores}`},
 			{Name: "flavor", JSONPath: `{.spec.template.metadata.annotations.\vm\.kubevirt\.io/flavor}`},
-			{Name: "memory", JSONPath: `{.spec.template.spec.domain.memory.guest}`},
+			{Name: "memory", JSONPath: `{.spec.template.spec.domain.memory.guest}`, isMemory: true},
 			{Name: "osName", JSONPath: `{.spec.template.metadata.annotations.\vm\.kubevirt\.io/os}`},
 			{Name: "ready", JSONPath: `{.status.conditions[?(@.type=='Ready')].status}`},
 			{Name: "status", JSONPath: `{.status.printableStatus}`},

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -58,6 +58,13 @@ var defaultTransformConfig = map[string]ResourceConfig{
 			{Name: "status", JSONPath: `{.status.phase}`},
 		},
 	},
+	"Node": {
+		properties: []ExtractProperty{
+			{Name: "ipAddress", JSONPath: `{.status.addresses[?(@.type=="InternalIP")].address}`},
+			{Name: "memoryAllocatable", JSONPath: `{.status.allocatable.memory}`},
+			{Name: "memoryCapacity", JSONPath: `{.status.capacity.memory}`},
+		},
+	},
 	"StorageClass.storage.k8s.io": {
 		properties: []ExtractProperty{
 			{Name: "allowVolumeExpansion", JSONPath: `{.allowVolumeExpansion}`},

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -2,13 +2,20 @@ package transforms
 
 // Declares a property to extract from a resource using jsonpath.
 type ExtractProperty struct {
-	Name     string // `json:"name,omitempty"`
-	JSONPath string // `json:"jsonpath,omitempty"`
-	// Denotes this property represents a memory field of a resource and must be converted to bytes for standardization
-	isMemory bool
+	Name     string   // `json:"name,omitempty"`
+	JSONPath string   // `json:"jsonpath,omitempty"`
+	DataType DataType // `json:"dataType,omitempty"`
 	// An internal property to denote this property should be set on the node's metadata instead.
 	metadataOnly bool
 }
+
+type DataType string
+
+const (
+	DataTypeBytes  DataType = "bytes"
+	DataTypeString DataType = "string"
+	DataTypeNumber DataType = "number"
+)
 
 // Declares the properties to extract from a given resource.
 type ResourceConfig struct {
@@ -63,8 +70,8 @@ var defaultTransformConfig = map[string]ResourceConfig{
 	"Node": {
 		properties: []ExtractProperty{
 			{Name: "ipAddress", JSONPath: `{.status.addresses[?(@.type=="InternalIP")].address}`},
-			{Name: "memoryAllocatable", JSONPath: `{.status.allocatable.memory}`, isMemory: true},
-			{Name: "memoryCapacity", JSONPath: `{.status.capacity.memory}`, isMemory: true},
+			{Name: "memoryAllocatable", JSONPath: `{.status.allocatable.memory}`, DataType: DataTypeBytes},
+			{Name: "memoryCapacity", JSONPath: `{.status.capacity.memory}`, DataType: DataTypeBytes},
 		},
 	},
 	"StorageClass.storage.k8s.io": {
@@ -95,7 +102,7 @@ var defaultTransformConfig = map[string]ResourceConfig{
 			{Name: "agentConnected", JSONPath: `{.status.conditions[?(@.type=="AgentConnected")].status}`},
 			{Name: "cpu", JSONPath: `{.spec.template.spec.domain.cpu.cores}`},
 			{Name: "flavor", JSONPath: `{.spec.template.metadata.annotations.\vm\.kubevirt\.io/flavor}`},
-			{Name: "memory", JSONPath: `{.spec.template.spec.domain.memory.guest}`, isMemory: true},
+			{Name: "memory", JSONPath: `{.spec.template.spec.domain.memory.guest}`, DataType: DataTypeBytes},
 			{Name: "osName", JSONPath: `{.spec.template.metadata.annotations.\vm\.kubevirt\.io/os}`},
 			{Name: "ready", JSONPath: `{.status.conditions[?(@.type=='Ready')].status}`},
 			{Name: "status", JSONPath: `{.status.printableStatus}`},

--- a/pkg/transforms/genericResource_test.go
+++ b/pkg/transforms/genericResource_test.go
@@ -99,7 +99,7 @@ func Test_genericResourceFromConfigVM(t *testing.T) {
 	AssertEqual("agentConnected", node.Properties["agentConnected"], "True", t)
 	AssertEqual("cpu", node.Properties["cpu"], int64(1), t)
 	AssertEqual("flavor", node.Properties["flavor"], "small", t)
-	AssertEqual("memory", node.Properties["memory"], "2Gi", t)
+	AssertEqual("memory", node.Properties["memory"], int64(2147483648), t) // 2Gi * 1024 * 1024 * 1024
 	AssertEqual("osName", node.Properties["osName"], "rhel9", t)
 	AssertEqual("ready", node.Properties["ready"], "True", t)
 	AssertEqual("status", node.Properties["status"], "Running", t)

--- a/pkg/transforms/genericresource.go
+++ b/pkg/transforms/genericresource.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/stolostron/search-collector/pkg/config"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/util/jsonpath"
-	"k8s.io/klog/v2"
 )
 
 // GenericResource ...
@@ -28,82 +26,7 @@ func GenericResourceBuilder(r *unstructured.Unstructured, additionalColumns ...E
 		Metadata:   genericMetadata(r),
 	}
 
-	// Check if a transform config exists for this resource and extract the additional properties.
-	group := r.GroupVersionKind().Group
-	kind := r.GetKind()
-	transformConfig, found := getTransformConfig(group, kind)
-
-	// Currently, only pull in the additionalPrinterColumns listed in the CRD if it's a Gatekeeper
-	// constraint or globally enabled.
-	if !found && (config.Cfg.CollectCRDPrinterColumns || group == "constraints.gatekeeper.sh") {
-		transformConfig = ResourceConfig{properties: additionalColumns}
-	}
-
-	for _, prop := range transformConfig.properties {
-		// Skip properties that are already set. This could happen if additionalPrinterColumns
-		// is overriding a generic property.
-		if _, ok := n.Properties[prop.Name]; ok {
-			continue
-		}
-
-		// Skip additionalPrinterColumns that should be ignored.
-		if !found && defaultTransformIgnoredFields[prop.Name] {
-			continue
-		}
-
-		jp := jsonpath.New(prop.Name)
-		parseErr := jp.Parse(prop.JSONPath)
-		if parseErr != nil {
-			klog.Errorf("Error parsing jsonpath [%s] for [%s.%s] prop: [%s]. Reason: %v",
-				prop.JSONPath, kind, group, prop.Name, parseErr)
-			continue
-		}
-
-		result, err := jp.FindResults(r.Object)
-		if err != nil {
-			// This error isn't always indicative of a problem, for example, when the object is created, it
-			// won't have a status yet, so the jsonpath returns an error until controller adds the status.
-			klog.V(1).Infof("Unable to extract prop [%s] from [%s.%s] Name: [%s]. Reason: %v",
-				prop.Name, kind, group, r.GetName(), err)
-			continue
-		}
-
-		if len(result) > 0 && len(result[0]) > 0 {
-			val := result[0][0].Interface()
-
-			if knownStringArrays[prop.Name] {
-				if _, ok := val.([]string); !ok {
-					klog.V(1).Infof("Ignoring the property [%s] from [%s.%s] Name: [%s]. Reason: not a string slice",
-						prop.Name, kind, group, r.GetName())
-					continue
-				}
-			}
-
-			if prop.metadataOnly {
-				strVal, ok := val.(string)
-
-				if !ok {
-					klog.V(1).Infof(
-						"Unable to extract metadata prop [%s] from [%s.%s] Name: [%s] since it's not a string: %v",
-						prop.Name, kind, group, r.GetName(),
-					)
-					continue
-				}
-
-				n.Metadata[prop.Name] = strVal
-			} else {
-				n.Properties[prop.Name] = val
-			}
-		} else {
-			klog.Errorf("Unexpected error extracting [%s] from [%s.%s] Name: [%s]. Result object is empty.",
-				prop.Name, kind, group, r.GetName())
-			continue
-		}
-	}
-
-	if found {
-		klog.V(5).Infof("Built [%s.%s] using transform config.\nNode: %+v\n", kind, group, n)
-	}
+	n = applyDefaultTransformConfig(n, r, additionalColumns...)
 
 	return &GenericResource{node: n}
 }

--- a/pkg/transforms/node.go
+++ b/pkg/transforms/node.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // NodeResource ...
@@ -23,7 +24,7 @@ type NodeResource struct {
 }
 
 // NodeResourceBuilder ...
-func NodeResourceBuilder(n *v1.Node) *NodeResource {
+func NodeResourceBuilder(n *v1.Node, r *unstructured.Unstructured, additionalColumns ...ExtractProperty) *NodeResource {
 	node := transformCommon(n) // Start off with the common properties
 
 	var roles []string
@@ -68,6 +69,8 @@ func NodeResourceBuilder(n *v1.Node) *NodeResource {
 		status += "-SchedulingDisabled" // Encoding to single string to work around limitations.
 	}
 	node.Properties["status"] = status
+
+	node = applyDefaultTransformConfig(node, r, additionalColumns...)
 
 	return &NodeResource{node: node}
 }

--- a/pkg/transforms/node_test.go
+++ b/pkg/transforms/node_test.go
@@ -30,8 +30,8 @@ func TestTransformNode(t *testing.T) {
 	AssertDeepEqual("role", node.Properties["role"], []string{"etcd", "main", "management", "proxy", "va"}, t)
 	AssertDeepEqual("status", node.Properties["status"], "Ready", t)
 	AssertEqual("ipAddress", node.Properties["ipAddress"], "1.1.1.1", t)
-	AssertEqual("memoryCapacity", node.Properties["memoryCapacity"], "24689408Ki", t)
-	AssertEqual("memoryAllocatable", node.Properties["memoryAllocatable"], "23538432Ki", t)
+	AssertEqual("memoryCapacity", node.Properties["memoryCapacity"], int64(25281953792), t)       // 24689408Ki * 1024
+	AssertEqual("memoryAllocatable", node.Properties["memoryAllocatable"], int64(24103354368), t) // 23538432Ki * 1024
 }
 
 func TestNodeBuildEdges(t *testing.T) {

--- a/pkg/transforms/node_test.go
+++ b/pkg/transforms/node_test.go
@@ -14,12 +14,13 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestTransformNode(t *testing.T) {
 	var n v1.Node
 	UnmarshalFile("node.json", &n, t)
-	node := NodeResourceBuilder(&n).BuildNode()
+	node := NodeResourceBuilder(&n, newUnstructuredNode()).BuildNode()
 
 	// Test only the fields that exist in node - the common test will test the other bits
 	AssertEqual("architecture", node.Properties["architecture"], "amd64", t)
@@ -28,6 +29,9 @@ func TestTransformNode(t *testing.T) {
 	AssertEqual("_systemUUID", node.Properties["_systemUUID"], "4BCDE0D7-CFFB-4A8F-B6F8-0026F347AD93", t)
 	AssertDeepEqual("role", node.Properties["role"], []string{"etcd", "main", "management", "proxy", "va"}, t)
 	AssertDeepEqual("status", node.Properties["status"], "Ready", t)
+	AssertEqual("ipAddress", node.Properties["ipAddress"], "1.1.1.1", t)
+	AssertEqual("memoryCapacity", node.Properties["memoryCapacity"], "24689408Ki", t)
+	AssertEqual("memoryAllocatable", node.Properties["memoryAllocatable"], "23538432Ki", t)
 }
 
 func TestNodeBuildEdges(t *testing.T) {
@@ -38,8 +42,43 @@ func TestNodeBuildEdges(t *testing.T) {
 	// Build edges from mock resource node.json
 	var n v1.Node
 	UnmarshalFile("node.json", &n, t)
-	edges := NodeResourceBuilder(&n).BuildEdges(nodeStore)
+	edges := NodeResourceBuilder(&n, newUnstructuredNode()).BuildEdges(nodeStore)
 
 	// Validate results
 	AssertEqual("Node has no edges:", len(edges), 0, t)
+}
+
+func newUnstructuredNode() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Node",
+		"status": map[string]interface{}{
+			"addresses": []interface{}{
+				map[string]interface{}{
+					"address": "1.1.1.1",
+					"type":    "InternalIP",
+				},
+				map[string]interface{}{
+					"address": "1.1.1.1",
+					"type":    "Hostname",
+				},
+			},
+			"allocatable": map[string]interface{}{
+				"cpu":               "7600m",
+				"ephemeral-storage": "240844852Ki",
+				"hugepages-1Gi":     "0",
+				"hugepages-2Mi":     "0",
+				"memory":            "23538432Ki",
+				"pods":              "80",
+			},
+			"capacity": map[string]interface{}{
+				"cpu":               "8",
+				"ephemeral-storage": "243044404Ki",
+				"hugepages-1Gi":     "0",
+				"hugepages-2Mi":     "0",
+				"memory":            "24689408Ki",
+				"pods":              "80",
+			},
+		},
+	}}
 }

--- a/pkg/transforms/transformer.go
+++ b/pkg/transforms/transformer.go
@@ -293,7 +293,7 @@ func TransformRoutine(input chan *Event, output chan NodeEvent) {
 			if err != nil {
 				panic(err) // Will be caught by handleRoutineExit
 			}
-			trans = NodeResourceBuilder(&typedResource)
+			trans = NodeResourceBuilder(&typedResource, event.Resource, event.AdditionalPrinterColumns...)
 
 		case [2]string{"PersistentVolume", ""}:
 			typedResource := core.PersistentVolume{}


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-16461 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-16461

### Description of changes
- Added more resources to index for kind:Node
- Refactored GenericResourceBuilder to further generalize resource transforming. Permits adding more fields to defaultTransformConfig for resources that have a specific transforms file.