### PR TITLE
use builtin min func

### DIFF
--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -77,14 +77,6 @@ func (inform *GenericInformer) Run(ctx context.Context) {
 	}
 }
 
-// Helper function that returns the smaller of two integers.
-func min(a, b int64) int64 {
-	if a > b {
-		return b
-	}
-	return a
-}
-
 // Helper function that creates a new unstructured resource with given Kind and UID.
 func newUnstructured(kind, uid string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{

--- a/pkg/informer/informer_test.go
+++ b/pkg/informer/informer_test.go
@@ -233,19 +233,6 @@ func Test_Run_retryBackoff(t *testing.T) {
 // 	}
 // }
 
-// Test helper function that returns the smaller integer
-func Test_min(t *testing.T) {
-	var a, b int64 = 1, 2
-
-	if min(a, b) != a {
-		t.Errorf("Expected a: %d to be smaller than b: %d", a, b)
-	}
-
-	if min(b, a) != a {
-		t.Errorf("Expected a: %d to be smaller than b: %d", a, b)
-	}
-}
-
 // Verify that Informer.watch() can be stopped.
 func Test_watch(t *testing.T) {
 	// Create informer instance to test.


### PR DESCRIPTION
### Description of changes
- Using builtin min func [introduced in Go 1.21](https://go.dev/blog/go1.21rc) since we bumped Go version.
