### PR TITLE
add image-digest value for sast-coverity-check-oci-ta

### DIFF
--- a/.tekton/search-collector-acm-214-pull-request.yaml
+++ b/.tekton/search-collector-acm-214-pull-request.yaml
@@ -463,6 +463,8 @@ spec:
           value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:07cb09253da53235f83d1a2327faebb8505091c509fc1e3af12a43cfe34f63a6
         - name: kind
           value: task
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
         resolver: bundles
       when:
       - input: $(params.skip-checks)


### PR DESCRIPTION
### Description of changes
- Added fix for failure: https://github.com/stolostron/search-collector/pull/551/checks?check_run_id=40876484755 according to https://github.com/konflux-ci/build-definitions/blob/main/task/sast-snyk-check/0.4/MIGRATION.md