### PR TITLE
sast-coverity-check-oci-ta image-digest from taskref params to params

### DIFF
--- a/.tekton/search-collector-acm-214-pull-request.yaml
+++ b/.tekton/search-collector-acm-214-pull-request.yaml
@@ -453,6 +453,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - coverity-availability-check
       taskRef:
@@ -463,8 +465,6 @@ spec:
           value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:07cb09253da53235f83d1a2327faebb8505091c509fc1e3af12a43cfe34f63a6
         - name: kind
           value: task
-        - name: image-digest
-          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
         resolver: bundles
       when:
       - input: $(params.skip-checks)


### PR DESCRIPTION
### Description of changes
- Moved image-digest param according to https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1745404637499059?thread_ts=1745339419.829389&cid=C04PZ7H0VA8