### PR TITLE
[release-2.11] fix sast-snyk-check params

### DIFF
--- a/.tekton/search-collector-acm-211-pull-request.yaml
+++ b/.tekton/search-collector-acm-211-pull-request.yaml
@@ -335,6 +335,11 @@ spec:
         values:
         - "false"
     - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
       runAfter:
       - clone-repository
       taskRef:
@@ -345,10 +350,6 @@ spec:
           value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.3@sha256:e0c1675c9813618910115f04fd6b3a9ff32d1bd4e2b9c975f1112aa1eae0d149
         - name: kind
           value: task
-        - name: image-digest
-          value: $(tasks.build-container.results.IMAGE_DIGEST)
-        - name: image-url
-          value: $(tasks.build-container.results.IMAGE_URL)
         resolver: bundles
       when:
       - input: $(params.skip-checks)


### PR DESCRIPTION
### Description of changes
- moved image-digest and image-url params according to https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1745404637499059?thread_ts=1745339419.829389&cid=C04PZ7H0VA8