### PR TITLE
ACM-20492 sender send deployed in hub

### DIFF
--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -196,6 +196,7 @@ func (s *Sender) send(payload Payload, expectedTotalResources int, expectedTotal
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hub-Cluster-Request", strconv.FormatBool(config.Cfg.DeployedInHub))
 	req.Header.Set("X-Overwrite-State", strconv.FormatBool(payload.ClearAll))
 
 	resp, err := s.httpClient.Do(req)


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-20492 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-20492

### Description of changes
- A few places use "local-cluster" hard-coded. Sending this bool in requests to the search-indexer permits the search-indexer requestLimiter middleware to use the bool as a check if requests come from the hub cluster instead of hard-coded "local-cluster" name.
Indexer pr: https://github.com/stolostron/search-indexer/pull/446