### PR TITLE
Fix collection of gatekeeper constraint properties

### DIFF
--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -631,14 +631,13 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 	kind := r.GetKind()
 	// Check if a transform config exists for this resource and extract the additional properties.
 	transformConfig, found := getTransformConfig(group, kind)
-	if !found {
-		return node
-	}
 
 	// Currently, only pull in the additionalPrinterColumns listed in the CRD if it's a Gatekeeper
 	// constraint or globally enabled.
 	if !found && (config.Cfg.CollectCRDPrinterColumns || group == "constraints.gatekeeper.sh") {
 		transformConfig = ResourceConfig{properties: additionalColumns}
+	} else if !found {
+		return node
 	}
 
 	for _, prop := range transformConfig.properties {

--- a/pkg/transforms/transformer_test.go
+++ b/pkg/transforms/transformer_test.go
@@ -77,6 +77,8 @@ func TestTransformRoutine(t *testing.T) {
 	).BuildNode()
 	gatekeeperConstraintNode.ResourceString = "k8srequiredlabels"
 	gatekeeperConstraintNode.Properties["_isExternal"] = false
+	gatekeeperConstraintNode.Properties["enforcementAction"] = "dryrun"
+	gatekeeperConstraintNode.Properties["totalViolations"] = 84
 
 	tests := []struct {
 		name     string


### PR DESCRIPTION
It had been returning too early after not finding the transform config - and the unit test was not actually checking for these properties.

Refs:
 - https://issues.redhat.com/browse/ACM-20932

<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-20932

### Description of changes
- Fix collection of gatekeeper constraint properties