### PR TITLE
Always mark noncompliant policy resources

### DIFF
--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -486,7 +486,7 @@ func TestReconcilerComplete(t *testing.T) {
 	}
 
 	noncompliant := configPolNode.Properties["_nonCompliantResources"]
-	if noncompliant != `[{"v":"v1","k":"Namespace","n":"default"}]` {
+	if noncompliant != `[{"v":"v1","k":"Namespace","n":"default"},{"v":"v1","k":"Namespace","n":"nonexistent"}]` {
 		t.Fatal("Incorrect _nonCompliantResources; got", noncompliant)
 	}
 }

--- a/pkg/transforms/policy.go
+++ b/pkg/transforms/policy.go
@@ -319,12 +319,12 @@ func (p PolicyResource) BuildEdges(ns NodeStore) []Edge {
 				DestKind:   obj.Kind,
 				DestUID:    res.UID,
 			})
-
-			if obj.EdgeType == noncompliantEdge {
-				nonCompliantResources = append(nonCompliantResources, obj)
-			}
 		} else {
 			missingResources = append(missingResources, obj)
+		}
+
+		if obj.EdgeType == noncompliantEdge {
+			nonCompliantResources = append(nonCompliantResources, obj)
 		}
 	}
 


### PR DESCRIPTION
Previously, related items on policies would only be put into the noncompliant list if they existed. However, many (not all) missing resources should also be considered as noncompliant.

Refs:
 - https://issues.redhat.com/browse/ACM-20098

<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-20098

### Description of changes
- Always mark noncompliant related resources of policies. 