### PR TITLE
Replace glog with klog

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ RUNTIME_MODE       | no       | production               | Running mode (develop
 ### Other Configuration Options
 
 - Environment variables can also be set in the `./config.json` for development. If both provide a value for a specific property, the environment variable overrides the file. You can define your own `config.json` file and pass it to the application with the following command: `-c <config_file>`
-- The application can take any flags for [glog](https://github.com/golang/glog), which passes them straight into glog. The glog flag `--logtostderr` is set to true by default.
+
 
 ### Dev Preview (Search Configurable Collection)
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ module github.com/stolostron/search-collector
 go 1.23.0
 
 require (
-	github.com/golang/glog v1.2.5
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible

--- a/go.sum
+++ b/go.sum
@@ -157,9 +157,6 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
-github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/pkg/config/kubeClient.go
+++ b/pkg/config/kubeClient.go
@@ -6,12 +6,12 @@ package config
 import (
 	"sync"
 
-	"github.com/golang/glog"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
 )
 
 var mutex sync.Mutex
@@ -26,7 +26,7 @@ func GetDynamicClient() dynamic.Interface {
 	}
 	newDynamicClient, err := dynamic.NewForConfig(GetKubeConfig())
 	if err != nil {
-		glog.Fatal("Cannot Construct Dynamic Client ", err)
+		klog.Fatal("Cannot Construct Dynamic Client ", err)
 	}
 	dynamicClient = newDynamicClient
 
@@ -38,15 +38,15 @@ func GetKubeConfig() *rest.Config {
 	var clientConfigError error
 
 	if Cfg.KubeConfig != "" {
-		glog.Infof("Creating k8s client using KubeConfig at: %s", Cfg.KubeConfig)
+		klog.Infof("Creating k8s client using KubeConfig at: %s", Cfg.KubeConfig)
 		clientConfig, clientConfigError = clientcmd.BuildConfigFromFlags("", Cfg.KubeConfig)
 	} else {
-		glog.V(2).Info("Creating k8s client using InClusterClientConfig()")
+		klog.V(2).Info("Creating k8s client using InClusterClientConfig()")
 		clientConfig, clientConfigError = rest.InClusterConfig()
 	}
 
 	if clientConfigError != nil {
-		glog.Fatal("Error getting Kube Config: ", clientConfigError)
+		klog.Fatal("Error getting Kube Config: ", clientConfigError)
 	}
 
 	return clientConfig
@@ -56,7 +56,7 @@ func GetKubeConfig() *rest.Config {
 func GetDiscoveryClient() *discovery.DiscoveryClient {
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(GetKubeConfig())
 	if err != nil {
-		glog.Fatal("Cannot Construct Discovery Client From Config: ", err)
+		klog.Fatal("Cannot Construct Discovery Client From Config: ", err)
 	}
 	return discoveryClient
 }
@@ -67,10 +67,10 @@ func GetKubeClient(config *rest.Config) *kubernetes.Clientset {
 	if config != nil {
 		kubeClient, err = kubernetes.NewForConfig(config)
 		if err != nil {
-			glog.Fatal("Cannot Construct Kube Client from Config: ", err)
+			klog.Fatal("Cannot Construct Kube Client from Config: ", err)
 		}
 	} else {
-		glog.Error("Cannot Construct Kube Client as input Config is nil")
+		klog.Error("Cannot Construct Kube Client as input Config is nil")
 	}
 	return kubeClient
 }

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/stolostron/search-collector/pkg/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,9 +33,9 @@ type GenericInformer struct {
 func InformerForResource(res schema.GroupVersionResource) (GenericInformer, error) {
 	i := GenericInformer{
 		gvr:           res,
-		AddFunc:       (func(interface{}) { glog.Warning("AddFunc not initialized for ", res.String()) }),
-		DeleteFunc:    (func(interface{}) { glog.Warning("DeleteFunc not initialized for ", res.String()) }),
-		UpdateFunc:    (func(interface{}, interface{}) { glog.Warning("UpdateFunc not init for ", res.String()) }),
+		AddFunc:       (func(interface{}) { klog.Warning("AddFunc not initialized for ", res.String()) }),
+		DeleteFunc:    (func(interface{}) { klog.Warning("DeleteFunc not initialized for ", res.String()) }),
+		UpdateFunc:    (func(interface{}, interface{}) { klog.Warning("UpdateFunc not init for ", res.String()) }),
 		initialized:   false,
 		retries:       0,
 		resourceIndex: make(map[string]string),
@@ -48,22 +48,22 @@ func (inform *GenericInformer) Run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			glog.Info("Informer stopped. ", inform.gvr.String())
+			klog.Info("Informer stopped. ", inform.gvr.String())
 			for key := range inform.resourceIndex {
-				glog.V(5).Infof("Stopping informer %s and removing resource with UID: %s", inform.gvr.Resource, key)
+				klog.V(5).Infof("Stopping informer %s and removing resource with UID: %s", inform.gvr.Resource, key)
 				obj := newUnstructured(inform.gvr.Resource, key)
 				inform.DeleteFunc(obj)
 			}
-			glog.V(5).Info("Informer stopped. ", inform.gvr.String())
+			klog.V(5).Info("Informer stopped. ", inform.gvr.String())
 			return
 		default:
 			if inform.retries > 0 {
 				// Backoff strategy: Adds 2 seconds each retry, up to 2 mins.
 				wait := time.Duration(min(inform.retries*2, 120)) * time.Second
-				glog.V(3).Infof("Waiting %s before retrying listAndWatch for %s", wait, inform.gvr.String())
+				klog.V(3).Infof("Waiting %s before retrying listAndWatch for %s", wait, inform.gvr.String())
 				time.Sleep(wait)
 			}
-			glog.V(3).Info("(Re)starting informer: ", inform.gvr.String())
+			klog.V(3).Info("(Re)starting informer: ", inform.gvr.String())
 			if inform.client == nil {
 				inform.client = config.GetDynamicClient()
 			}
@@ -102,19 +102,19 @@ func (inform *GenericInformer) listAndResync() error {
 	for {
 		resources, listError := inform.client.Resource(inform.gvr).List(context.TODO(), opts)
 		if listError != nil {
-			glog.Warningf("Error listing resources for %s.  Error: %s", inform.gvr.String(), listError)
+			klog.Warningf("Error listing resources for %s.  Error: %s", inform.gvr.String(), listError)
 			inform.retries++
 			return listError
 		}
 
 		// Add all resources.
 		for i := range resources.Items {
-			glog.V(5).Infof("KIND: %s UUID: %s, ResourceVersion: %s",
+			klog.V(5).Infof("KIND: %s UUID: %s, ResourceVersion: %s",
 				inform.gvr.Resource, resources.Items[i].GetUID(), resources.Items[i].GetResourceVersion())
 			inform.AddFunc(&resources.Items[i])
 			newResourceIndex[string(resources.Items[i].GetUID())] = resources.Items[i].GetResourceVersion()
 		}
-		glog.V(3).Infof("Listed\t[Group: %s \tKind: %s]  ===>  resourceTotal: %d  resourceVersion: %s",
+		klog.V(3).Infof("Listed\t[Group: %s \tKind: %s]  ===>  resourceTotal: %d  resourceVersion: %s",
 			inform.gvr.Group, inform.gvr.Resource, len(resources.Items), resources.GetResourceVersion())
 
 		// Check if there's more items and set the "continue" option for the next request.
@@ -130,7 +130,7 @@ func (inform *GenericInformer) listAndResync() error {
 	// Delete resources from previous state that no longer exist in the new state.
 	for key := range inform.resourceIndex {
 		if _, exist := newResourceIndex[key]; !exist {
-			glog.V(3).Infof("Resource does not exist. Deleting resource: %s with UID: %s", inform.gvr.Resource, key)
+			klog.V(3).Infof("Resource does not exist. Deleting resource: %s with UID: %s", inform.gvr.Resource, key)
 			obj := newUnstructured(inform.gvr.Resource, key)
 			inform.DeleteFunc(obj)
 			delete(inform.resourceIndex, key)
@@ -143,13 +143,13 @@ func (inform *GenericInformer) listAndResync() error {
 func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 	watch, watchError := inform.client.Resource(inform.gvr).Watch(context.TODO(), metav1.ListOptions{})
 	if watchError != nil {
-		glog.Warningf("Error watching resources for %s.  Error: %s", inform.gvr.String(), watchError)
+		klog.Warningf("Error watching resources for %s.  Error: %s", inform.gvr.String(), watchError)
 		inform.retries++
 		return
 	}
 	defer watch.Stop()
 
-	glog.V(3).Infof("Watching\t[Group: %s \tKind: %s]", inform.gvr.Group, inform.gvr.Resource)
+	klog.V(3).Infof("Watching\t[Group: %s \tKind: %s]", inform.gvr.Group, inform.gvr.Resource)
 
 	watchEvents := watch.ResultChan()
 	inform.retries = 0 // Reset retries because we have a successful list and a watch.
@@ -157,17 +157,17 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 	for {
 		select {
 		case <-stopper:
-			glog.V(2).Info("Informer watch() was stopped. ", inform.gvr.String())
+			klog.V(2).Info("Informer watch() was stopped. ", inform.gvr.String())
 			return
 
 		case event := <-watchEvents: // Read events from the watch channel.
 			//  Process ADDED, MODIFIED, DELETED, and ERROR events.
 			switch event.Type {
 			case "ADDED":
-				glog.V(5).Infof("Received ADDED event. Kind: %s ", inform.gvr.Resource)
+				klog.V(5).Infof("Received ADDED event. Kind: %s ", inform.gvr.Resource)
 				obj, ok := event.Object.(*unstructured.Unstructured)
 				if !ok {
-					glog.Warningf("Error converting %s event.Object to unstructured.Unstructured on ADDED event.",
+					klog.Warningf("Error converting %s event.Object to unstructured.Unstructured on ADDED event.",
 						inform.gvr.Resource)
 					continue
 				}
@@ -175,10 +175,10 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 				inform.resourceIndex[string(obj.GetUID())] = obj.GetResourceVersion()
 
 			case "MODIFIED":
-				glog.V(5).Infof("Received MODIFY event. Kind: %s ", inform.gvr.Resource)
+				klog.V(5).Infof("Received MODIFY event. Kind: %s ", inform.gvr.Resource)
 				obj, ok := event.Object.(*unstructured.Unstructured)
 				if !ok {
-					glog.Warningf("Error converting %s event.Object to unstructured.Unstructured on MODIFIED event",
+					klog.Warningf("Error converting %s event.Object to unstructured.Unstructured on MODIFIED event",
 						inform.gvr.Resource)
 					continue
 				}
@@ -187,10 +187,10 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 				inform.resourceIndex[string(obj.GetUID())] = obj.GetResourceVersion()
 
 			case "DELETED":
-				glog.V(5).Infof("Received DELETED event. Kind: %s ", inform.gvr.Resource)
+				klog.V(5).Infof("Received DELETED event. Kind: %s ", inform.gvr.Resource)
 				obj, ok := event.Object.(*unstructured.Unstructured)
 				if !ok {
-					glog.Warningf("Error converting %s event.Object to unstructured.Unstructured on DELETED event",
+					klog.Warningf("Error converting %s event.Object to unstructured.Unstructured on DELETED event",
 						inform.gvr.Resource)
 					continue
 				}
@@ -199,11 +199,11 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 				delete(inform.resourceIndex, string(obj.GetUID()))
 
 			case "ERROR":
-				glog.V(2).Infof("Received ERROR event. Ending listAndWatch() for %s event: %s", inform.gvr.String(), event)
+				klog.V(2).Infof("Received ERROR event. Ending listAndWatch() for %s event: %s", inform.gvr.String(), event)
 				return
 
 			default:
-				glog.V(2).Infof("Received unexpected event. Ending listAndWatch() for %s", inform.gvr.String())
+				klog.V(2).Infof("Received unexpected event. Ending listAndWatch() for %s", inform.gvr.String())
 				return
 			}
 		}
@@ -216,7 +216,7 @@ func (inform *GenericInformer) WaitUntilInitialized(timeout time.Duration) {
 	start := time.Now()
 	for !inform.initialized {
 		if time.Since(start) > timeout {
-			glog.V(2).Infof("Informer [%s] timed out after %s waiting for initialization.", inform.gvr.String(), timeout)
+			klog.V(2).Infof("Informer [%s] timed out after %s waiting for initialization.", inform.gvr.String(), timeout)
 			break
 		}
 		time.Sleep(time.Duration(10) * time.Millisecond)

--- a/pkg/lease/lease.go
+++ b/pkg/lease/lease.go
@@ -7,12 +7,12 @@ import (
 	"os"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/stolostron/search-collector/pkg/config"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 )
 
 // LeaseReconciler reconciles a Secret object
@@ -36,20 +36,20 @@ func (r *LeaseReconciler) Reconcile() {
 	if err != nil {
 		// Try to create or update the lease on in the managed cluster's namespace on the hub cluster.
 		if errors.IsNotFound(err) && r.HubKubeClient != nil {
-			glog.V(2).Infof("Trying to update lease on the hub.")
+			klog.V(2).Infof("Trying to update lease on the hub.")
 
 			if err := r.updateLease(r.ClusterName, r.HubKubeClient); err != nil {
-				glog.Errorf("Failed to update lease %s/%s: %v on hub cluster", r.LeaseName, r.ClusterName, err)
+				klog.Errorf("Failed to update lease %s/%s: %v on hub cluster", r.LeaseName, r.ClusterName, err)
 				r.reloadClient() // Refresh the kube client to ensure the error was not caused by a stale config.
 			}
 		} else {
-			glog.Errorf("Failed to update lease %s/%s: %v on managed cluster", r.LeaseName, r.componentNamespace, err)
+			klog.Errorf("Failed to update lease %s/%s: %v on managed cluster", r.LeaseName, r.componentNamespace, err)
 		}
 	}
 }
 
 func (r *LeaseReconciler) updateLease(namespace string, client kubernetes.Interface) error {
-	glog.V(2).Infof("Trying to update lease %q/%q", namespace, r.LeaseName)
+	klog.V(2).Infof("Trying to update lease %q/%q", namespace, r.LeaseName)
 	context := context.TODO()
 	lease, err := client.CoordinationV1().Leases(namespace).Get(context, r.LeaseName, metav1.GetOptions{})
 
@@ -69,28 +69,28 @@ func (r *LeaseReconciler) updateLease(namespace string, client kubernetes.Interf
 			},
 		}
 		if _, err := client.CoordinationV1().Leases(namespace).Create(context, lease, metav1.CreateOptions{}); err != nil {
-			glog.Errorf("Unable to create addon lease %q/%q . error:%v", namespace, r.LeaseName, err)
+			klog.Errorf("Unable to create addon lease %q/%q . error:%v", namespace, r.LeaseName, err)
 
 			return err
 		}
 
-		glog.V(2).Infof("Addon lease %q/%q created", namespace, r.LeaseName)
+		klog.V(2).Infof("Addon lease %q/%q created", namespace, r.LeaseName)
 
 		return nil
 	case err != nil:
-		glog.Errorf("Unable to get addon lease %q/%q . error:%v", namespace, r.LeaseName, err)
+		klog.Errorf("Unable to get addon lease %q/%q . error:%v", namespace, r.LeaseName, err)
 
 		return err
 	default:
 		// update lease
 		lease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
 		if _, err = client.CoordinationV1().Leases(namespace).Update(context, lease, metav1.UpdateOptions{}); err != nil {
-			glog.Errorf("Unable to update cluster lease %q/%q . error:%v", namespace, r.LeaseName, err)
+			klog.Errorf("Unable to update cluster lease %q/%q . error:%v", namespace, r.LeaseName, err)
 
 			return err
 		}
 
-		glog.V(2).Infof("Addon lease %q/%q updated", namespace, r.LeaseName)
+		klog.V(2).Infof("Addon lease %q/%q updated", namespace, r.LeaseName)
 
 		return nil
 	}

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/glog"
 	lru "github.com/golang/groupcache/lru"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stolostron/search-collector/pkg/config"
@@ -29,6 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/helm/pkg/proto/hapi/release"
+	"k8s.io/klog/v2"
 )
 
 type NodeEdge struct {
@@ -465,9 +465,9 @@ func TestReconcilerComplete(t *testing.T) {
 	const Nodes = 55
 	const Edges = 61
 	if len(com.Edges) != Edges || com.TotalEdges != Edges || len(com.Nodes) != Nodes || com.TotalNodes != Nodes {
-		glog.Infof("len edges: %d", len(com.Edges))
+		klog.Infof("len edges: %d", len(com.Edges))
 		for _, edge := range com.Edges {
-			glog.Info("Src: ", ns.ByUID[edge.SourceUID].Properties["kind"], " Type: ", edge.EdgeType, " Dest: ", ns.ByUID[edge.DestUID].Properties["kind"])
+			klog.Info("Src: ", ns.ByUID[edge.SourceUID].Properties["kind"], " Type: ", edge.EdgeType, " Dest: ", ns.ByUID[edge.DestUID].Properties["kind"])
 		}
 
 		t.Log("Expected "+strconv.Itoa(Nodes)+" nodes, but found ", len(com.Nodes))

--- a/pkg/send/httpsClient.go
+++ b/pkg/send/httpsClient.go
@@ -16,11 +16,12 @@ import (
 	"net/http"
 	"os"
 
+	"k8s.io/klog/v2"
+
 	"github.com/stolostron/search-collector/pkg/config"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme"
-	"k8s.io/client-go/rest"
 
-	"github.com/golang/glog"
+	"k8s.io/client-go/rest"
 )
 
 func getHTTPSClient() (client http.Client) {
@@ -31,7 +32,7 @@ func getHTTPSClient() (client http.Client) {
 		aggregatorRESTClient, err := rest.UnversionedRESTClientFor(config.Cfg.AggregatorConfig)
 		if err != nil {
 			// Exit because this is an unrecoverable configuration problem.
-			glog.Fatal("Error getting httpClient from kubeconfig. Original error: ", err)
+			klog.Fatal("Error getting httpClient from kubeconfig. Original error: ", err)
 		}
 		client = *(aggregatorRESTClient.Client)
 		return client
@@ -52,7 +53,7 @@ func getHTTPSClient() (client http.Client) {
 		caCert, err := os.ReadFile("./sslcert/tls.crt")
 		cert, err2 := tls.LoadX509KeyPair("./sslcert/tls.crt", "./sslcert/tls.key")
 		if err != nil || err2 != nil {
-			glog.Error("WARNING: Using insecure TLS connection. Couldn't load certs ", err, err2)
+			klog.Error("WARNING: Using insecure TLS connection. Couldn't load certs ", err, err2)
 			tlsCfg.InsecureSkipVerify = true
 		} else {
 			caCertPool := x509.NewCertPool()

--- a/pkg/transforms/argoapplication.go
+++ b/pkg/transforms/argoapplication.go
@@ -6,8 +6,8 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/golang/glog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
 // ArgoApplicationResource ...
@@ -149,7 +149,7 @@ func ArgoApplicationResourceBuilder(a *ArgoApplication) *ArgoApplicationResource
 
 func TruncateText(text string, width int) string {
 	if width < 0 {
-		glog.Warningf("text truncation width is less than zero, width: %v", width)
+		klog.Warningf("text truncation width is less than zero, width: %v", width)
 
 		return ""
 	}
@@ -205,12 +205,12 @@ func (a ArgoApplicationResource) BuildEdges(ns NodeStore) []Edge {
 
 	// add missing application resource as a property
 	if len(missingResc) != 0 {
-		glog.V(5).Infof("ArgoApplication [%s] has %d missing resources:\n%+v",
+		klog.V(5).Infof("ArgoApplication [%s] has %d missing resources:\n%+v",
 			a.node.Properties["name"], len(missingResc), missingResc)
 		rescb, err := json.Marshal(missingResc)
 
 		if err != nil {
-			glog.Error("ArgoApplication transform failed to marshal missingResc", err)
+			klog.Error("ArgoApplication transform failed to marshal missingResc", err)
 		} else {
 			a.node.Properties["_missingResources"] = string(rescb)
 		}

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -16,7 +16,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/golang/glog"
 	"github.com/stolostron/search-collector/pkg/config"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -134,7 +133,7 @@ func addReleaseOwnerUID(node Node, ns NodeStore) {
 	if releaseNode, ok := ns.ByKindNamespaceName["HelmRelease"][ownerNamespace][ownerName]; ok {
 		node.Metadata["OwnerUID"] = releaseNode.UID
 	} else {
-		glog.V(3).Infof("HelmRelease node not found for namespace: %s name: %s", ownerNamespace, ownerName)
+		klog.V(3).Infof("HelmRelease node not found for namespace: %s name: %s", ownerNamespace, ownerName)
 	}
 }
 
@@ -324,7 +323,7 @@ func edgesByOwner(destUID string, ns NodeStore, nodeInfo NodeInfo, seenDests []s
 				}
 			}
 		} else {
-			glog.V(4).Infof("For %s, %s, %s edge not created: ownerUID %s not found",
+			klog.V(4).Infof("For %s, %s, %s edge not created: ownerUID %s not found",
 				nodeInfo.Kind, nodeInfo.NameSpace+"/"+nodeInfo.Name, nodeInfo.EdgeType, destUID)
 		}
 	}
@@ -361,7 +360,7 @@ func edgesByDestinationName(
 				} else if len(destKindInfo) == 1 {
 					name = destKindInfo[0]
 				} else {
-					glog.V(4).Infof("For %s, %s edge not created as %s is not in namespace/name format",
+					klog.V(4).Infof("For %s, %s edge not created as %s is not in namespace/name format",
 						nodeInfo.NameSpace+"/"+nodeInfo.Kind+"/"+nodeInfo.Name, nodeInfo.EdgeType, destKind+"/"+name)
 					continue
 				}
@@ -406,7 +405,7 @@ func edgesByDestinationName(
 					}
 				}
 			} else {
-				glog.V(4).Infof("For %s, %s edge not created as %s named %s not found",
+				klog.V(4).Infof("For %s, %s edge not created as %s named %s not found",
 					nodeInfo.NameSpace+"/"+nodeInfo.Kind+"/"+nodeInfo.Name,
 					nodeInfo.EdgeType, destKind, nodeInfo.NameSpace+"/"+name)
 			}
@@ -469,11 +468,11 @@ func edgesByDeployerSubscriber(nodeInfo NodeInfo, ns NodeStore) []Edge {
 					}
 				}
 			} else {
-				glog.V(4).Infof("For %s, %s edge not created as %s named %s not found",
+				klog.V(4).Infof("For %s, %s edge not created as %s named %s not found",
 					nodeInfo.NameSpace+"/"+nodeInfo.Kind+"/"+nodeInfo.Name, nodeInfo.EdgeType, destKind, namespace+"/"+name)
 			}
 		} else {
-			glog.V(4).Infof("For %s, %s edge not created as %s is not in namespace/name format",
+			klog.V(4).Infof("For %s, %s edge not created as %s is not in namespace/name format",
 				nodeInfo.NameSpace+"/"+nodeInfo.Kind+"/"+nodeInfo.Name, nodeInfo.EdgeType, destNsName)
 		}
 		return depSubedges

--- a/pkg/transforms/helmrelease.go
+++ b/pkg/transforms/helmrelease.go
@@ -15,11 +15,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/stolostron/search-collector/pkg/config"
 	"gopkg.in/yaml.v3"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/helm/pkg/proto/hapi/release"
+	"k8s.io/klog/v2"
 )
 
 type HelmReleaseResource struct {
@@ -77,7 +77,7 @@ func getSummarizedManifestResources(h HelmReleaseResource) []SummarizedManifestR
 	smr := []SummarizedManifestResource{}
 
 	if h.Release == nil {
-		glog.V(2).Infof("Cannot retrieve manifest from nil Helm Release %s", h.GetLabels()["NAME"])
+		klog.V(2).Infof("Cannot retrieve manifest from nil Helm Release %s", h.GetLabels()["NAME"])
 		return smr // Can't have any resources without the Release
 	}
 
@@ -100,11 +100,11 @@ func getSummarizedManifestResources(h HelmReleaseResource) []SummarizedManifestR
 		// We unmarshal the struct
 		err := yaml.Unmarshal([]byte(resource), &tmpsmr)
 		if err != nil {
-			glog.Errorf("Unmarshalling Helm Release %s failed: %v", h.GetLabels()["NAME"], err)
+			klog.Errorf("Unmarshalling Helm Release %s failed: %v", h.GetLabels()["NAME"], err)
 		} else if tmpsmr.Kind != "" && tmpsmr.Metadata.Name != "" { // ... and if both resource kind and name defined...
 			smr = append(smr, tmpsmr) // ... prep `KIND` and `NAME` for BuildEdges
 		} else { // this shouldn't happen
-			glog.Warningf("kind or name not found for resource in Helm Release %s", h.GetLabels()["NAME"])
+			klog.Warningf("kind or name not found for resource in Helm Release %s", h.GetLabels()["NAME"])
 		}
 	}
 
@@ -160,11 +160,11 @@ func (h HelmReleaseResource) BuildEdges(ns NodeStore) []Edge {
 					})
 				}
 			} else {
-				glog.V(2).Infof("%s/%s edge ownedBy Helm Release not created: Helm Release %s not found",
+				klog.V(2).Infof("%s/%s edge ownedBy Helm Release not created: Helm Release %s not found",
 					kind, name, h.GetLabels()["NAME"])
 			}
 		} else {
-			glog.V(2).Infof("edge ownedBy Helm Release %s not created: Resource %s/%s not found in namespace %s",
+			klog.V(2).Infof("edge ownedBy Helm Release %s not created: Resource %s/%s not found in namespace %s",
 				h.GetLabels()["NAME"], kind, name, namespace)
 		}
 	}

--- a/pkg/transforms/pod.go
+++ b/pkg/transforms/pod.go
@@ -14,18 +14,18 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/glog"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 )
 
 // PodResource ...
 type PodResource struct {
 	node Node
-	Spec v1.PodSpec
+	Spec corev1.PodSpec
 }
 
 // PodResourceBuilder ...
-func PodResourceBuilder(p *v1.Pod) *PodResource {
+func PodResourceBuilder(p *corev1.Pod) *PodResource {
 	// Loop over spec to get the container and image names
 	var containers []string
 	var images []string
@@ -202,7 +202,7 @@ func (p PodResource) BuildEdges(ns NodeStore) []Edge {
 				})
 			}
 		} else {
-			glog.V(2).Infof("Pod %s runsOn edge not created: Node %s not found",
+			klog.V(2).Infof("Pod %s runsOn edge not created: Node %s not found",
 				p.node.Properties["namespace"].(string)+"/"+p.node.Properties["name"].(string), "_NONE/"+nodeName)
 		}
 	}

--- a/pkg/transforms/policy.go
+++ b/pkg/transforms/policy.go
@@ -15,10 +15,10 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/golang/glog"
 	policy "github.com/stolostron/governance-policy-propagator/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
 )
 
 // PolicyResource ...
@@ -39,7 +39,7 @@ func PolicyResourceBuilder(p *policy.Policy) *PolicyResource {
 	node.Properties["remediationAction"] = string(p.Spec.RemediationAction)
 	node.Properties["disabled"] = p.Spec.Disabled
 	node.Properties["numRules"] = len(p.Spec.PolicyTemplates)
-	// For the root policy (on hub, in non cluster ns), it doesn’t have an overall status. it has status per cluster.
+	// For the root policy (on hub, in non cluster ns), it doesn't have an overall status. it has status per cluster.
 	// On managed cluster, compliance is reported by status.compliant
 	if p.Status.ComplianceState != "" {
 		node.Properties["compliant"] = string(p.Status.ComplianceState)
@@ -331,7 +331,7 @@ func (p PolicyResource) BuildEdges(ns NodeStore) []Edge {
 	if len(missingResources) > 0 {
 		missingString, err := json.Marshal(missingResources)
 		if err != nil {
-			glog.Error("Failed to marshal a missing resource", err)
+			klog.Error("Failed to marshal a missing resource", err)
 		} else {
 			p.node.Properties["_missingResources"] = string(missingString)
 		}
@@ -342,7 +342,7 @@ func (p PolicyResource) BuildEdges(ns NodeStore) []Edge {
 	if len(nonCompliantResources) > 0 {
 		nonCompString, err := json.Marshal(nonCompliantResources)
 		if err != nil {
-			glog.Error("Failed to marshal a non compliant resource", err)
+			klog.Error("Failed to marshal a non compliant resource", err)
 		} else {
 			p.node.Properties["_nonCompliantResources"] = string(nonCompString)
 		}

--- a/pkg/transforms/transformer.go
+++ b/pkg/transforms/transformer.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/golang/glog"
 	ocpapp "github.com/openshift/api/apps/v1"
 	policy "github.com/stolostron/governance-policy-propagator/api/v1"
 	klusterletaddon "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
@@ -28,6 +27,7 @@ import (
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
 	acmapp "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 	appHelmRelease "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/helmrelease/v1"
 	subscription "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
@@ -157,10 +157,10 @@ var (
 )
 
 func NewTransformer(inputChan chan *Event, outputChan chan NodeEvent, numRoutines int) Transformer {
-	glog.Info("Transformer started")
+	klog.Info("Transformer started")
 	nr := numRoutines
 	if numRoutines < 1 {
-		glog.Warning(numRoutines, "is an invalid number of routines for Transformer. Using 1 instead.")
+		klog.Warning(numRoutines, "is an invalid number of routines for Transformer. Using 1 instead.")
 		nr = 1
 	}
 
@@ -180,7 +180,7 @@ func NewTransformer(inputChan chan *Event, outputChan chan NodeEvent, numRoutine
 // because it was already taken out by the previous run.
 func TransformRoutine(input chan *Event, output chan NodeEvent) {
 	defer handleRoutineExit(input, output)
-	glog.Info("Starting transformer routine")
+	klog.Info("Starting transformer routine")
 
 	for {
 		var trans Transform
@@ -449,8 +449,8 @@ func TransformRoutine(input chan *Event, output chan NodeEvent) {
 func handleRoutineExit(input chan *Event, output chan NodeEvent) {
 	// Recover and check the value. If we are here because of a panic, something will be in it.
 	if r := recover(); r != nil { // Case where we got here from a panic
-		glog.Errorf("Error in transformer routine: %v\n", r)
-		glog.Error(string(debug.Stack()))
+		klog.Errorf("Error in transformer routine: %v\n", r)
+		klog.Error(string(debug.Stack()))
 
 		// Start up a new routine with the same channels as the old one. The bad input will be gone since the
 		// old routine (the one that just crashed) took it out of the channel.

--- a/pkg/transforms/vapbinding.go
+++ b/pkg/transforms/vapbinding.go
@@ -6,12 +6,12 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/golang/glog"
 	admissionregistration "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 )
 
 type VapBindingResource struct {
@@ -58,14 +58,14 @@ func VapBindingResourceBuilder(v *unstructured.Unstructured) *VapBindingResource
 	}
 
 	if err != nil {
-		glog.Errorf("Failed to parse the ValidatingAdmissionPolicyBinding %s paramRef: %v", v.GetName(), err)
+		klog.Errorf("Failed to parse the ValidatingAdmissionPolicyBinding %s paramRef: %v", v.GetName(), err)
 
 		return binding
 	}
 
 	paramRefBytes, err := json.Marshal(paramRefMap)
 	if err != nil {
-		glog.Errorf("Failed to parse the ValidatingAdmissionPolicyBinding %s paramRef: %v", v.GetName(), err)
+		klog.Errorf("Failed to parse the ValidatingAdmissionPolicyBinding %s paramRef: %v", v.GetName(), err)
 
 		return binding
 	}
@@ -74,7 +74,7 @@ func VapBindingResourceBuilder(v *unstructured.Unstructured) *VapBindingResource
 
 	err = json.Unmarshal(paramRefBytes, paramRef)
 	if err != nil {
-		glog.Errorf("Failed to parse the ValidatingAdmissionPolicyBinding %s paramRef: %v", v.GetName(), err)
+		klog.Errorf("Failed to parse the ValidatingAdmissionPolicyBinding %s paramRef: %v", v.GetName(), err)
 
 		return binding
 	}


### PR DESCRIPTION
### Related Issue
N/A

### Description of changes
- The project now consistently uses klog/v2 for logging instead of the older glog library, which aligns with Kubernetes ecosystem best practices. All logging functionality should work exactly the same, as klog provides the same API as glog but with additional features and better integration with the Kubernetes ecosystem
