### PR TITLE
ACM-22579 collect status conditions

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	AggregatorPort           string       `env:"AGGREGATOR_PORT"`             // Port of the Aggregator
 	CollectAnnotations       bool         `env:"COLLECT_ANNOTATIONS"`         // Collect all annotations with values <=64 characters
 	CollectCRDPrinterColumns bool         `env:"COLLECT_CRD_PRINTER_COLUMNS"` // Enable collecting additional printer columns in the CRD
+	CollectStatusConditions  bool         `env:"COLLECT_STATUS_CONDITIONS"`   // Collect all status condition types and values if present
 	ClusterName              string       `env:"CLUSTER_NAME"`                // The name of of the cluster where this pod is running
 	DeployedInHub            bool         `env:"DEPLOYED_IN_HUB"`             // Tracks if deployed in the Hub or Managed cluster
 	HeartbeatMS              int          `env:"HEARTBEAT_MS"`                // Interval(ms) to send empty payload to ensure connection
@@ -117,6 +118,16 @@ func InitConfig() {
 		Cfg.CollectAnnotations, err = strconv.ParseBool(collectAnnotations)
 		if err != nil {
 			klog.Errorf("Error parsing env COLLECT_ANNOTATIONS, defaulting to false: %v", err)
+		}
+	}
+
+	if collectStatusConditions := os.Getenv("COLLECT_STATUS_CONDITIONS"); collectStatusConditions != "" {
+		klog.Infof("Using COLLECT_STATUS_CONDITIONS from environment: %s", collectStatusConditions)
+
+		var err error
+		Cfg.CollectStatusConditions, err = strconv.ParseBool(collectStatusConditions)
+		if err != nil {
+			klog.Errorf("Error parsing env COLLECT_STATUS_CONDITIONS, defaulting to false: %v", err)
 		}
 	}
 

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -77,10 +77,10 @@ func createNodeEvents(resourceNameOne string, resourceNameTwo string) []tr.NodeE
 	p.Kind = "Pod"
 	p.Namespace = "default"
 	p.UID = "5678"
-	podNode := tr.PodResourceBuilder(&p).BuildNode()
+	podNode := tr.PodResourceBuilder(&p, &unstructured.Unstructured{}).BuildNode()
 	podNode.Metadata["OwnerUID"] = "local-cluster/1234"
 	podNode.ResourceString = resourceNameTwo
-	podEdges := tr.PodResourceBuilder(&p).BuildEdges
+	podEdges := tr.PodResourceBuilder(&p, &unstructured.Unstructured{}).BuildEdges
 
 	events.BuildNode = append(events.BuildNode, podNode)
 	events.BuildEdges = append(events.BuildEdges, podEdges)

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -710,6 +710,25 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 					)
 				}
 				node.Properties[prop.Name] = mem
+			} else if prop.StatusConditions {
+				conditionsMap := make(map[string]string, 0)
+
+				conditions, ok := val.([]interface{})
+				if !ok {
+					klog.V(1).Infof("Unable to extract prop [%s] from [%s.%s] Name: [%s] since it's not []interface: %v",
+						prop.Name, kind, group, r.GetName(), val)
+					continue
+				}
+				for _, cond := range conditions {
+					condMap, ok := cond.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					condType, _ := condMap["type"].(string)
+					status, _ := condMap["status"].(string)
+					conditionsMap[condType] = status
+				}
+				node.Properties[prop.Name] = conditionsMap
 			} else {
 				node.Properties[prop.Name] = val
 			}

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -7,6 +7,8 @@ type ExtractProperty struct {
 	DataType DataType // `json:"dataType,omitempty"`
 	// An internal property to denote this property should be set on the node's metadata instead.
 	metadataOnly bool
+	// A property to denote that we should gather status conditions on this resource
+	StatusConditions bool
 }
 
 type DataType string
@@ -100,6 +102,7 @@ var defaultTransformConfig = map[string]ResourceConfig{
 	"VirtualMachine.kubevirt.io": {
 		properties: []ExtractProperty{
 			{Name: "agentConnected", JSONPath: `{.status.conditions[?(@.type=="AgentConnected")].status}`},
+			{Name: "conditions", JSONPath: `{.status.conditions}`, StatusConditions: true},
 			{Name: "cpu", JSONPath: `{.spec.template.spec.domain.cpu.cores}`},
 			{Name: "flavor", JSONPath: `{.spec.template.metadata.annotations.\vm\.kubevirt\.io/flavor}`},
 			{Name: "memory", JSONPath: `{.spec.template.spec.domain.memory.guest}`, DataType: DataTypeBytes},
@@ -126,7 +129,7 @@ var defaultTransformConfig = map[string]ResourceConfig{
 		properties: []ExtractProperty{
 			{Name: "ready", JSONPath: `{.status.conditions[?(@.type=='Ready')].status}`},
 			{Name: "_conditionReadyReason", JSONPath: `{.status.conditions[?(@.type=='Ready')].reason}`},
-			{Name: "phase",  JSONPath: `{.status.phase}`},
+			{Name: "phase", JSONPath: `{.status.phase}`},
 			{Name: "indications", JSONPath: `{.status.indications}`}, // this is an array of strings - will collect array items separated by ;
 			{Name: "sourceKind", JSONPath: `{.spec.source.kind}`},
 			{Name: "sourceName", JSONPath: `{.spec.source.name}`},

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -7,8 +7,6 @@ type ExtractProperty struct {
 	DataType DataType // `json:"dataType,omitempty"`
 	// An internal property to denote this property should be set on the node's metadata instead.
 	metadataOnly bool
-	// A property to denote that we should gather status conditions on this resource
-	StatusConditions bool
 }
 
 type DataType string
@@ -102,7 +100,6 @@ var defaultTransformConfig = map[string]ResourceConfig{
 	"VirtualMachine.kubevirt.io": {
 		properties: []ExtractProperty{
 			{Name: "agentConnected", JSONPath: `{.status.conditions[?(@.type=="AgentConnected")].status}`},
-			{Name: "conditions", JSONPath: `{.status.conditions}`, StatusConditions: true},
 			{Name: "cpu", JSONPath: `{.spec.template.spec.domain.cpu.cores}`},
 			{Name: "flavor", JSONPath: `{.spec.template.metadata.annotations.\vm\.kubevirt\.io/flavor}`},
 			{Name: "memory", JSONPath: `{.spec.template.spec.domain.memory.guest}`, DataType: DataTypeBytes},

--- a/pkg/transforms/genericResource_test.go
+++ b/pkg/transforms/genericResource_test.go
@@ -97,7 +97,7 @@ func Test_genericResourceFromConfigVM(t *testing.T) {
 
 	// Verify properties defined in the transform config
 	AssertEqual("agentConnected", node.Properties["agentConnected"], "True", t)
-	AssertDeepEqual("conditions", node.Properties["conditions"], map[string]string{
+	AssertDeepEqual("condition", node.Properties["condition"], map[string]string{
 		"AgentConnected":   "True",
 		"DataVolumesReady": "True",
 		"Initialized":      "True",

--- a/pkg/transforms/genericResource_test.go
+++ b/pkg/transforms/genericResource_test.go
@@ -97,6 +97,13 @@ func Test_genericResourceFromConfigVM(t *testing.T) {
 
 	// Verify properties defined in the transform config
 	AssertEqual("agentConnected", node.Properties["agentConnected"], "True", t)
+	AssertDeepEqual("conditions", node.Properties["conditions"], map[string]string{
+		"AgentConnected":   "True",
+		"DataVolumesReady": "True",
+		"Initialized":      "True",
+		"LiveMigratable":   "False",
+		"Ready":            "True",
+	}, t)
 	AssertEqual("cpu", node.Properties["cpu"], int64(1), t)
 	AssertEqual("flavor", node.Properties["flavor"], "small", t)
 	AssertEqual("memory", node.Properties["memory"], int64(2147483648), t) // 2Gi * 1024 * 1024 * 1024

--- a/pkg/transforms/node_test.go
+++ b/pkg/transforms/node_test.go
@@ -32,6 +32,12 @@ func TestTransformNode(t *testing.T) {
 	AssertEqual("ipAddress", node.Properties["ipAddress"], "1.1.1.1", t)
 	AssertEqual("memoryCapacity", node.Properties["memoryCapacity"], int64(25281953792), t)       // 24689408Ki * 1024
 	AssertEqual("memoryAllocatable", node.Properties["memoryAllocatable"], int64(24103354368), t) // 23538432Ki * 1024
+	AssertDeepEqual("condition", node.Properties["condition"], map[string]string{
+		"DiskPressure":   "False",
+		"MemoryPressure": "False",
+		"PIDPressure":    "False",
+		"Ready":          "True",
+	}, t)
 }
 
 func TestNodeBuildEdges(t *testing.T) {
@@ -78,6 +84,24 @@ func newUnstructuredNode() *unstructured.Unstructured {
 				"hugepages-2Mi":     "0",
 				"memory":            "24689408Ki",
 				"pods":              "80",
+			},
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type":   "Ready",
+					"status": "True",
+				},
+				map[string]interface{}{
+					"type":   "DiskPressure",
+					"status": "False",
+				},
+				map[string]interface{}{
+					"type":   "MemoryPressure",
+					"status": "False",
+				},
+				map[string]interface{}{
+					"type":   "PIDPressure",
+					"status": "False",
+				},
 			},
 		},
 	}}

--- a/pkg/transforms/pod.go
+++ b/pkg/transforms/pod.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 )
 
@@ -25,7 +26,7 @@ type PodResource struct {
 }
 
 // PodResourceBuilder ...
-func PodResourceBuilder(p *corev1.Pod) *PodResource {
+func PodResourceBuilder(p *corev1.Pod, r *unstructured.Unstructured) *PodResource {
 	// Loop over spec to get the container and image names
 	var containers []string
 	var images []string
@@ -123,6 +124,8 @@ func PodResourceBuilder(p *corev1.Pod) *PodResource {
 	if p.Status.StartTime != nil {
 		node.Properties["startedAt"] = p.Status.StartTime.UTC().Format(time.RFC3339)
 	}
+
+	node = applyDefaultTransformConfig(node, r)
 
 	return &PodResource{node: node, Spec: p.Spec}
 }

--- a/pkg/transforms/transformer.go
+++ b/pkg/transforms/transformer.go
@@ -355,7 +355,7 @@ func TransformRoutine(input chan *Event, output chan NodeEvent) {
 			if err != nil {
 				panic(err) // Will be caught by handleRoutineExit
 			}
-			trans = PodResourceBuilder(&typedResource)
+			trans = PodResourceBuilder(&typedResource, event.Resource)
 
 		case [2]string{"Policy", POLICY_OPEN_CLUSTER_MANAGEMENT_IO},
 			[2]string{"Policy", "policies.open-cluster-management.io"}:


### PR DESCRIPTION
### Related Issues
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-22579
https://issues.redhat.com/browse/ACM-2071

### Description of changes
- Added ability to index status conditions as map[string]string just like labels. Added config to enable for all resource kinds, defaults to false and will gather conditions on VMs, Nodes, Pods, Search, and MCH by default while we test the functionality before eventually enabling for all resources.
