### PR TITLE
ACM-22579 index pvc claim names and data volume names on vm, vmi on vmim

### DIFF
--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -205,7 +205,7 @@ func edgesByDefaultTransformConfig(ret []Edge, currNode Node, ns NodeStore) []Ed
 				ret = append(ret, Edge{
 					SourceKind: kind,
 					SourceUID:  currNode.UID,
-					EdgeType:   EdgeType(e.Type),
+					EdgeType:   e.Type,
 					DestKind:   n.Properties["kind"].(string),
 					DestUID:    n.UID,
 				})
@@ -218,7 +218,7 @@ func edgesByDefaultTransformConfig(ret []Edge, currNode Node, ns NodeStore) []Ed
 					ret = append(ret, Edge{
 						SourceKind: kind,
 						SourceUID:  currNode.UID,
-						EdgeType:   EdgeType(e.Type),
+						EdgeType:   e.Type,
 						DestKind:   n.Properties["kind"].(string),
 						DestUID:    n.UID,
 					})

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -12,7 +12,6 @@ package transforms
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -201,7 +200,6 @@ func edgesByDefaultTransformConfig(ret []Edge, currNode Node, ns NodeStore) []Ed
 			case string:
 				n, ok := ns.ByKindNamespaceName[e.ToKind][namespace][v]
 				if !ok {
-					fmt.Println("!ok")
 					return ret
 				}
 				ret = append(ret, Edge{
@@ -211,16 +209,10 @@ func edgesByDefaultTransformConfig(ret []Edge, currNode Node, ns NodeStore) []Ed
 					DestKind:   n.Properties["kind"].(string),
 					DestUID:    n.UID,
 				})
-			case []interface{}:
+			case []string:
 				for _, item := range v {
-					strItem, ok := item.(string)
+					n, ok := ns.ByKindNamespaceName[e.ToKind][namespace][item]
 					if !ok {
-						fmt.Printf("Non-string item in list for metadata key %s: %v\n", e.Name, item)
-						continue
-					}
-					n, ok := ns.ByKindNamespaceName[e.ToKind][namespace][strItem]
-					if !ok {
-						fmt.Println("!ok")
 						continue
 					}
 					ret = append(ret, Edge{

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -675,15 +675,13 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 
 		// TODO: generalize to handle other types of nested arrays, and what if its deeply nested?
 		if len(result) > 0 && len(result[0]) > 0 {
-			if kind == "VirtualMachine" && group == "kubevirt.io" {
-				if prop.Name == "dataVolumeNames" || prop.Name == "pvcClaimNames" {
-					var nestedSlice []interface{}
-					for _, v := range result[0] {
-						nestedSlice = append(nestedSlice, v.Interface())
-					}
-					node.Properties[prop.Name] = nestedSlice
-					continue
+			if kind == "VirtualMachine" && group == "kubevirt.io" && (prop.Name == "dataVolumeNames" || prop.Name == "pvcClaimNames") {
+				var nestedSlice []interface{}
+				for _, v := range result[0] {
+					nestedSlice = append(nestedSlice, v.Interface())
 				}
+				node.Properties[prop.Name] = nestedSlice
+				continue
 			}
 			val := result[0][0].Interface()
 

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -209,9 +209,9 @@ func edgesByDefaultTransformConfig(ret []Edge, currNode Node, ns NodeStore) []Ed
 					DestKind:   n.Properties["kind"].(string),
 					DestUID:    n.UID,
 				})
-			case []string:
+			case []interface{}:
 				for _, item := range v {
-					n, ok := ns.ByKindNamespaceName[e.ToKind][namespace][item]
+					n, ok := ns.ByKindNamespaceName[e.ToKind][namespace][item.(string)]
 					if !ok {
 						continue
 					}

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -200,7 +200,7 @@ func edgesByDefaultTransformConfig(ret []Edge, currNode Node, ns NodeStore) []Ed
 			case string:
 				n, ok := ns.ByKindNamespaceName[e.ToKind][namespace][v]
 				if !ok {
-					return ret
+					continue
 				}
 				ret = append(ret, Edge{
 					SourceKind: kind,

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -673,7 +673,18 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 			continue
 		}
 
+		// TODO: generalize to handle other types of nested arrays, and what if its deeply nested?
 		if len(result) > 0 && len(result[0]) > 0 {
+			if kind == "VirtualMachine" && group == "kubevirt.io" {
+				if prop.Name == "dataVolumeNames" || prop.Name == "pvcClaimNames" {
+					var nestedSlice []interface{}
+					for _, v := range result[0] {
+						nestedSlice = append(nestedSlice, v.Interface())
+					}
+					node.Properties[prop.Name] = nestedSlice
+					continue
+				}
+			}
 			val := result[0][0].Interface()
 
 			if knownStringArrays[prop.Name] {

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -735,6 +735,18 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 		}
 
 		if len(result) > 0 && len(result[0]) > 0 {
+			if prop.DataType == DataTypeSlice {
+				var slice []interface{}
+				for _, v := range result[0] {
+					slice = append(slice, v.Interface())
+				}
+				if prop.metadataOnly {
+					node.Metadata[prop.Name] = slice
+				} else {
+					node.Properties[prop.Name] = slice
+				}
+				continue
+			}
 			val := result[0][0].Interface()
 
 			if knownStringArrays[prop.Name] {
@@ -746,14 +758,6 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 			}
 
 			if prop.metadataOnly {
-				if kind == "VirtualMachine" && group == "kubevirt.io" && (prop.Name == "dataVolumeNames" || prop.Name == "pvcClaimNames") {
-					var nestedSlice []interface{}
-					for _, v := range result[0] {
-						nestedSlice = append(nestedSlice, v.Interface())
-					}
-					node.Metadata[prop.Name] = nestedSlice
-					continue
-				}
 				strVal, ok := val.(string)
 
 				if !ok {

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -107,10 +107,12 @@ var defaultTransformConfig = map[string]ResourceConfig{
 		properties: []ExtractProperty{
 			{Name: "agentConnected", JSONPath: `{.status.conditions[?(@.type=="AgentConnected")].status}`},
 			{Name: "cpu", JSONPath: `{.spec.template.spec.domain.cpu.cores}`},
+			{Name: "dataVolumeNames", JSONPath: `{.spec.template.spec.domain.volumes[*].dataVolume.name}`},
 			{Name: "_description", JSONPath: `{.metadata.annotations.description}`},
 			{Name: "flavor", JSONPath: `{.spec.template.metadata.annotations.\vm\.kubevirt\.io/flavor}`},
 			{Name: "memory", JSONPath: `{.spec.template.spec.domain.memory.guest}`, DataType: DataTypeBytes},
 			{Name: "osName", JSONPath: `{.spec.template.metadata.annotations.\vm\.kubevirt\.io/os}`},
+			{Name: "pvcClaimNames", JSONPath: `{.spec.template.spec.domain.volumes[*].persistentVolumeClaim.claimName}`},
 			{Name: "ready", JSONPath: `{.status.conditions[?(@.type=='Ready')].status}`},
 			{Name: "runStrategy", JSONPath: `{.spec.runStrategy}`},
 			{Name: "status", JSONPath: `{.status.printableStatus}`},
@@ -136,6 +138,7 @@ var defaultTransformConfig = map[string]ResourceConfig{
 		properties: []ExtractProperty{
 			{Name: "phase", JSONPath: `{.status.phase}`},
 			{Name: "endTime", JSONPath: `{.status.migrationState.endTimestamp}`},
+			{Name: "vmiName", JSONPath: `{.spec.vmiName}`},
 		},
 	},
 	"VirtualMachineSnapshot.snapshot.kubevirt.io": {

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -107,12 +107,12 @@ var defaultTransformConfig = map[string]ResourceConfig{
 		properties: []ExtractProperty{
 			{Name: "agentConnected", JSONPath: `{.status.conditions[?(@.type=="AgentConnected")].status}`},
 			{Name: "cpu", JSONPath: `{.spec.template.spec.domain.cpu.cores}`},
-			{Name: "dataVolumeNames", JSONPath: `{.spec.template.spec.domain.volumes[*].dataVolume.name}`},
+			{Name: "dataVolumeNames", JSONPath: `{.spec.template.spec.domain.volumes[*].dataVolume.name}`, metadataOnly: true},
 			{Name: "_description", JSONPath: `{.metadata.annotations.description}`},
 			{Name: "flavor", JSONPath: `{.spec.template.metadata.annotations.\vm\.kubevirt\.io/flavor}`},
 			{Name: "memory", JSONPath: `{.spec.template.spec.domain.memory.guest}`, DataType: DataTypeBytes},
 			{Name: "osName", JSONPath: `{.spec.template.metadata.annotations.\vm\.kubevirt\.io/os}`},
-			{Name: "pvcClaimNames", JSONPath: `{.spec.template.spec.domain.volumes[*].persistentVolumeClaim.claimName}`},
+			{Name: "pvcClaimNames", JSONPath: `{.spec.template.spec.domain.volumes[*].persistentVolumeClaim.claimName}`, metadataOnly: true},
 			{Name: "ready", JSONPath: `{.status.conditions[?(@.type=='Ready')].status}`},
 			{Name: "runStrategy", JSONPath: `{.spec.runStrategy}`},
 			{Name: "status", JSONPath: `{.status.printableStatus}`},
@@ -138,7 +138,7 @@ var defaultTransformConfig = map[string]ResourceConfig{
 		properties: []ExtractProperty{
 			{Name: "phase", JSONPath: `{.status.phase}`},
 			{Name: "endTime", JSONPath: `{.status.migrationState.endTimestamp}`},
-			{Name: "vmiName", JSONPath: `{.spec.vmiName}`},
+			{Name: "vmiName", JSONPath: `{.spec.vmiName}`, metadataOnly: true},
 		},
 	},
 	"VirtualMachineSnapshot.snapshot.kubevirt.io": {

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -129,8 +129,8 @@ var defaultTransformConfig = map[string]ResourceConfig{
 			{Name: "_specRunStrategy", JSONPath: `{.spec.runStrategy}`},
 		},
 		edges: []ExtractEdge{
-			{Name: "dataVolumeNames", ToKind: "DataVolume", Type: "attachedTo"},
-			{Name: "pvcClaimNames", ToKind: "PersistentVolumeClaim", Type: "attachedTo"},
+			{Name: "dataVolumeNames", ToKind: "DataVolume", Type: attachedTo},
+			{Name: "pvcClaimNames", ToKind: "PersistentVolumeClaim", Type: attachedTo},
 		},
 	},
 	"VirtualMachineInstance.kubevirt.io": {
@@ -153,7 +153,7 @@ var defaultTransformConfig = map[string]ResourceConfig{
 			{Name: "vmiName", JSONPath: `{.spec.vmiName}`, metadataOnly: true},
 		},
 		edges: []ExtractEdge{
-			{Name: "vmiName", ToKind: "VirtualMachineInstance", Type: "migrationOf"},
+			{Name: "vmiName", ToKind: "VirtualMachineInstance", Type: migrationOf},
 		},
 	},
 	"VirtualMachineSnapshot.snapshot.kubevirt.io": {

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -9,6 +9,12 @@ type ExtractProperty struct {
 	metadataOnly bool
 }
 
+type ExtractEdge struct {
+	Name   string
+	ToKind string
+	Type   string
+}
+
 type DataType string
 
 const (
@@ -21,6 +27,7 @@ const (
 // Declares the properties to extract from a given resource.
 type ResourceConfig struct {
 	properties []ExtractProperty // `json:"properties,omitempty"`
+	edges      []ExtractEdge
 }
 
 var (
@@ -121,6 +128,10 @@ var defaultTransformConfig = map[string]ResourceConfig{
 			{Name: "_specRunning", JSONPath: `{.spec.running}`},
 			{Name: "_specRunStrategy", JSONPath: `{.spec.runStrategy}`},
 		},
+		edges: []ExtractEdge{
+			{Name: "dataVolumeNames", ToKind: "DataVolume", Type: "uses"},
+			{Name: "pvcClaimNames", ToKind: "PersistentVolumeClaim", Type: "uses"},
+		},
 	},
 	"VirtualMachineInstance.kubevirt.io": {
 		properties: []ExtractProperty{
@@ -140,6 +151,9 @@ var defaultTransformConfig = map[string]ResourceConfig{
 			{Name: "phase", JSONPath: `{.status.phase}`},
 			{Name: "endTime", JSONPath: `{.status.migrationState.endTimestamp}`},
 			{Name: "vmiName", JSONPath: `{.spec.vmiName}`, metadataOnly: true},
+		},
+		edges: []ExtractEdge{
+			{Name: "vmiName", ToKind: "VirtualMachineInstance", Type: "migrationOf"},
 		},
 	},
 	"VirtualMachineSnapshot.snapshot.kubevirt.io": {

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -13,6 +13,7 @@ type DataType string
 
 const (
 	DataTypeBytes  DataType = "bytes"
+	DataTypeSlice  DataType = "slice"
 	DataTypeString DataType = "string"
 	DataTypeNumber DataType = "number"
 )
@@ -107,12 +108,12 @@ var defaultTransformConfig = map[string]ResourceConfig{
 		properties: []ExtractProperty{
 			{Name: "agentConnected", JSONPath: `{.status.conditions[?(@.type=="AgentConnected")].status}`},
 			{Name: "cpu", JSONPath: `{.spec.template.spec.domain.cpu.cores}`},
-			{Name: "dataVolumeNames", JSONPath: `{.spec.template.spec.domain.volumes[*].dataVolume.name}`, metadataOnly: true},
+			{Name: "dataVolumeNames", JSONPath: `{.spec.template.spec.domain.volumes[*].dataVolume.name}`, metadataOnly: true, DataType: DataTypeSlice},
 			{Name: "_description", JSONPath: `{.metadata.annotations.description}`},
 			{Name: "flavor", JSONPath: `{.spec.template.metadata.annotations.\vm\.kubevirt\.io/flavor}`},
 			{Name: "memory", JSONPath: `{.spec.template.spec.domain.memory.guest}`, DataType: DataTypeBytes},
 			{Name: "osName", JSONPath: `{.spec.template.metadata.annotations.\vm\.kubevirt\.io/os}`},
-			{Name: "pvcClaimNames", JSONPath: `{.spec.template.spec.domain.volumes[*].persistentVolumeClaim.claimName}`, metadataOnly: true},
+			{Name: "pvcClaimNames", JSONPath: `{.spec.template.spec.domain.volumes[*].persistentVolumeClaim.claimName}`, metadataOnly: true, DataType: DataTypeSlice},
 			{Name: "ready", JSONPath: `{.status.conditions[?(@.type=='Ready')].status}`},
 			{Name: "runStrategy", JSONPath: `{.spec.runStrategy}`},
 			{Name: "status", JSONPath: `{.status.printableStatus}`},

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -10,9 +10,9 @@ type ExtractProperty struct {
 }
 
 type ExtractEdge struct {
-	Name   string
-	ToKind string
-	Type   string
+	Name   string   // `json:"name,omitempty"`
+	ToKind string   // `json:"toKind,omitempty"`
+	Type   EdgeType // `json:"type,omitempty"`
 }
 
 type DataType string
@@ -27,7 +27,7 @@ const (
 // Declares the properties to extract from a given resource.
 type ResourceConfig struct {
 	properties []ExtractProperty // `json:"properties,omitempty"`
-	edges      []ExtractEdge
+	edges      []ExtractEdge     // `json:"edges,omitempty"`
 }
 
 var (
@@ -129,8 +129,8 @@ var defaultTransformConfig = map[string]ResourceConfig{
 			{Name: "_specRunStrategy", JSONPath: `{.spec.runStrategy}`},
 		},
 		edges: []ExtractEdge{
-			{Name: "dataVolumeNames", ToKind: "DataVolume", Type: "uses"},
-			{Name: "pvcClaimNames", ToKind: "PersistentVolumeClaim", Type: "uses"},
+			{Name: "dataVolumeNames", ToKind: "DataVolume", Type: "attachedTo"},
+			{Name: "pvcClaimNames", ToKind: "PersistentVolumeClaim", Type: "attachedTo"},
 		},
 	},
 	"VirtualMachineInstance.kubevirt.io": {

--- a/pkg/transforms/genericResource_test.go
+++ b/pkg/transforms/genericResource_test.go
@@ -93,14 +93,14 @@ func Test_edgesFromVirtualMachine(t *testing.T) {
 	edges = edgesByDefaultTransformConfig(edges, node, nodeStore)
 
 	AssertEqual("VM edge total: ", len(edges), 4, t)
-	AssertEqual("VM uses", edges[0].DestKind, "PersistentVolumeClaim", t)
-	AssertEqual("VM uses pvc name: ", edges[0].DestUID, "uuid-123-pvc-1", t)
-	AssertEqual("VM uses", edges[1].DestKind, "PersistentVolumeClaim", t)
-	AssertEqual("VM uses pvc name: ", edges[1].DestUID, "uuid-123-pvc-2", t)
-	AssertEqual("VM uses", edges[2].DestKind, "DataVolume", t)
-	AssertEqual("VM uses dv name: ", edges[2].DestUID, "uuid-123-dv-1", t)
-	AssertEqual("VM uses", edges[3].DestKind, "DataVolume", t)
-	AssertEqual("VM uses dv name: ", edges[3].DestUID, "uuid-123-dv-2", t)
+	AssertEqual("VM uses", edges[0].DestKind, "DataVolume", t)
+	AssertEqual("VM uses dv name: ", edges[0].DestUID, "uuid-123-dv-1", t)
+	AssertEqual("VM uses", edges[1].DestKind, "DataVolume", t)
+	AssertEqual("VM uses dv name: ", edges[1].DestUID, "uuid-123-dv-2", t)
+	AssertEqual("VM uses", edges[2].DestKind, "PersistentVolumeClaim", t)
+	AssertEqual("VM uses pvc name: ", edges[2].DestUID, "uuid-123-pvc-1", t)
+	AssertEqual("VM uses", edges[3].DestKind, "PersistentVolumeClaim", t)
+	AssertEqual("VM uses pvc name: ", edges[3].DestUID, "uuid-123-pvc-2", t)
 }
 
 func Test_allowListedForAnnotations(t *testing.T) {

--- a/pkg/transforms/genericResource_test.go
+++ b/pkg/transforms/genericResource_test.go
@@ -59,6 +59,50 @@ func Test_genericResourceFromConfig(t *testing.T) {
 	assert.Nil(t, node.Properties["annotations"])
 }
 
+func Test_edgesFromVirtualMachineInstanceMigration(t *testing.T) {
+	var r unstructured.Unstructured
+	UnmarshalFile("virtualmachineinstancemigration.json", &r, t)
+	node := GenericResourceBuilder(&r).BuildNode()
+
+	nodes := []Node{
+		{UID: "uuid-123-vmim", Properties: map[string]interface{}{"kind": "VirtualMachineInstance", "namespace": "ugo", "name": "rhel-10-crimson-eagle-72"}},
+	}
+	nodeStore := BuildFakeNodeStore(nodes)
+
+	edges := make([]Edge, 0)
+	edges = edgesByDefaultTransformConfig(edges, node, nodeStore)
+
+	AssertEqual("VMI edge total: ", len(edges), 1, t)
+	AssertEqual("VMI migrationOf", edges[0].DestKind, "VirtualMachineInstance", t)
+}
+
+func Test_edgesFromVirtualMachine(t *testing.T) {
+	var r unstructured.Unstructured
+	UnmarshalFile("virtualmachine.json", &r, t)
+	node := GenericResourceBuilder(&r).BuildNode()
+
+	nodes := []Node{
+		{UID: "uuid-123-pvc-1", Properties: map[string]interface{}{"kind": "PersistentVolumeClaim", "namespace": "openshift-cnv", "name": "the-claim-is-persistent"}},
+		{UID: "uuid-123-pvc-2", Properties: map[string]interface{}{"kind": "PersistentVolumeClaim", "namespace": "openshift-cnv", "name": "the-claim-is-too-persistent"}},
+		{UID: "uuid-123-dv-1", Properties: map[string]interface{}{"kind": "DataVolume", "namespace": "openshift-cnv", "name": "rhel-8-amber-fish-51-volume"}},
+		{UID: "uuid-123-dv-2", Properties: map[string]interface{}{"kind": "DataVolume", "namespace": "openshift-cnv", "name": "rhel-8-amber-fish-51-volume-2"}},
+	}
+	nodeStore := BuildFakeNodeStore(nodes)
+
+	edges := make([]Edge, 0)
+	edges = edgesByDefaultTransformConfig(edges, node, nodeStore)
+
+	AssertEqual("VM edge total: ", len(edges), 4, t)
+	AssertEqual("VM uses", edges[0].DestKind, "PersistentVolumeClaim", t)
+	AssertEqual("VM uses pvc name: ", edges[0].DestUID, "uuid-123-pvc-1", t)
+	AssertEqual("VM uses", edges[1].DestKind, "PersistentVolumeClaim", t)
+	AssertEqual("VM uses pvc name: ", edges[1].DestUID, "uuid-123-pvc-2", t)
+	AssertEqual("VM uses", edges[2].DestKind, "DataVolume", t)
+	AssertEqual("VM uses dv name: ", edges[2].DestUID, "uuid-123-dv-1", t)
+	AssertEqual("VM uses", edges[3].DestKind, "DataVolume", t)
+	AssertEqual("VM uses dv name: ", edges[3].DestUID, "uuid-123-dv-2", t)
+}
+
 func Test_allowListedForAnnotations(t *testing.T) {
 	obj := unstructured.Unstructured{}
 	obj.SetGroupVersionKind(schema.GroupVersionKind{
@@ -105,12 +149,10 @@ func Test_genericResourceFromConfigVM(t *testing.T) {
 		"Ready":            "True",
 	}, t)
 	AssertEqual("cpu", node.Properties["cpu"], int64(1), t)
-	AssertDeepEqual("dataVolumeNames", node.Properties["dataVolumeNames"], []interface{}{"rhel-8-amber-fish-51-volume", "rhel-8-amber-fish-51-volume-2"}, t)
 	AssertEqual("_description", node.Properties["_description"], "some description", t)
 	AssertEqual("flavor", node.Properties["flavor"], "small", t)
 	AssertEqual("memory", node.Properties["memory"], int64(2147483648), t) // 2Gi
 	AssertEqual("osName", node.Properties["osName"], "rhel9", t)
-	AssertDeepEqual("pvcClaimNames", node.Properties["pvcClaimNames"], []interface{}{"the-claim-is-persistent", "the-claim-is-too-persistent"}, t)
 	AssertEqual("ready", node.Properties["ready"], "True", t)
 	AssertEqual("runStrategy", node.Properties["runStrategy"], nil, t)
 	AssertEqual("status", node.Properties["status"], "Running", t)
@@ -157,7 +199,6 @@ func Test_genericResourceFromConfigVMIM(t *testing.T) {
 	// Verify properties defined in the transform config
 	AssertEqual("endTime", node.Properties["endTime"], "2025-07-11T14:42:32Z", t)
 	AssertEqual("phase", node.Properties["phase"], "Scheduling", t)
-	AssertEqual("vmiName", node.Properties["vmiName"], "rhel-10-crimson-eagle-72", t)
 }
 
 func Test_genericResourceFromConfigVMSnapshot(t *testing.T) {

--- a/pkg/transforms/genericResource_test.go
+++ b/pkg/transforms/genericResource_test.go
@@ -93,14 +93,14 @@ func Test_edgesFromVirtualMachine(t *testing.T) {
 	edges = edgesByDefaultTransformConfig(edges, node, nodeStore)
 
 	AssertEqual("VM edge total: ", len(edges), 4, t)
-	AssertEqual("VM uses", edges[0].DestKind, "DataVolume", t)
-	AssertEqual("VM uses dv name: ", edges[0].DestUID, "uuid-123-dv-1", t)
-	AssertEqual("VM uses", edges[1].DestKind, "DataVolume", t)
-	AssertEqual("VM uses dv name: ", edges[1].DestUID, "uuid-123-dv-2", t)
-	AssertEqual("VM uses", edges[2].DestKind, "PersistentVolumeClaim", t)
-	AssertEqual("VM uses pvc name: ", edges[2].DestUID, "uuid-123-pvc-1", t)
-	AssertEqual("VM uses", edges[3].DestKind, "PersistentVolumeClaim", t)
-	AssertEqual("VM uses pvc name: ", edges[3].DestUID, "uuid-123-pvc-2", t)
+	AssertEqual("VM attachedTo", edges[0].DestKind, "DataVolume", t)
+	AssertEqual("VM attachedTo dv name: ", edges[0].DestUID, "uuid-123-dv-1", t)
+	AssertEqual("VM attachedTo", edges[1].DestKind, "DataVolume", t)
+	AssertEqual("VM attachedTo dv name: ", edges[1].DestUID, "uuid-123-dv-2", t)
+	AssertEqual("VM attachedTo", edges[2].DestKind, "PersistentVolumeClaim", t)
+	AssertEqual("VM attachedTo pvc name: ", edges[2].DestUID, "uuid-123-pvc-1", t)
+	AssertEqual("VM attachedTo", edges[3].DestKind, "PersistentVolumeClaim", t)
+	AssertEqual("VM attachedTo pvc name: ", edges[3].DestUID, "uuid-123-pvc-2", t)
 }
 
 func Test_allowListedForAnnotations(t *testing.T) {

--- a/pkg/transforms/genericResource_test.go
+++ b/pkg/transforms/genericResource_test.go
@@ -105,10 +105,12 @@ func Test_genericResourceFromConfigVM(t *testing.T) {
 		"Ready":            "True",
 	}, t)
 	AssertEqual("cpu", node.Properties["cpu"], int64(1), t)
+	AssertDeepEqual("dataVolumeNames", node.Properties["dataVolumeNames"], []interface{}{"rhel-8-amber-fish-51-volume", "rhel-8-amber-fish-51-volume-2"}, t)
 	AssertEqual("_description", node.Properties["_description"], "some description", t)
 	AssertEqual("flavor", node.Properties["flavor"], "small", t)
 	AssertEqual("memory", node.Properties["memory"], int64(2147483648), t) // 2Gi
 	AssertEqual("osName", node.Properties["osName"], "rhel9", t)
+	AssertDeepEqual("pvcClaimNames", node.Properties["pvcClaimNames"], []interface{}{"the-claim-is-persistent", "the-claim-is-too-persistent"}, t)
 	AssertEqual("ready", node.Properties["ready"], "True", t)
 	AssertEqual("runStrategy", node.Properties["runStrategy"], nil, t)
 	AssertEqual("status", node.Properties["status"], "Running", t)
@@ -155,6 +157,7 @@ func Test_genericResourceFromConfigVMIM(t *testing.T) {
 	// Verify properties defined in the transform config
 	AssertEqual("endTime", node.Properties["endTime"], "2025-07-11T14:42:32Z", t)
 	AssertEqual("phase", node.Properties["phase"], "Scheduling", t)
+	AssertEqual("vmiName", node.Properties["vmiName"], "rhel-10-crimson-eagle-72", t)
 }
 
 func Test_genericResourceFromConfigVMSnapshot(t *testing.T) {

--- a/pkg/transforms/transformer.go
+++ b/pkg/transforms/transformer.go
@@ -122,14 +122,14 @@ func NewNodeEvent(event *Event, trans Transform, resourceString string) NodeEven
 // A specific type designated for relationship type
 type EdgeType string
 
-// TODO: to be used later
-// Differnet values for EdgeType
-// const (
-// 	ownedBy    EdgeType = "ownedBy"
-// 	attachedTo EdgeType = "attachedTo"
-// 	runsOn     EdgeType = "runsOn"
-// 	selects    EdgeType = "selects"
-// )
+// Different values for EdgeType
+const (
+	ownedBy     EdgeType = "ownedBy"
+	attachedTo  EdgeType = "attachedTo"
+	migrationOf EdgeType = "migrationOf"
+	runsOn      EdgeType = "runsOn"
+	selects     EdgeType = "selects"
+)
 
 // Structure to hold Edge, containing the type and UIDs to relationships
 type Edge struct {

--- a/test-data/virtualmachine.json
+++ b/test-data/virtualmachine.json
@@ -127,9 +127,27 @@
                             }
                         },
                         {
+                            "name": "rootdisk-2",
+                            "dataVolume": {
+                                "name": "rhel-8-amber-fish-51-volume-2"
+                            }
+                        },
+                        {
                             "name": "cloudinitdisk",
                             "cloudInitNoDisk": {
                                 "userData": "#cloud-config\nchpasswd:\nexpire: false\npassword: q9hy-mzra-3vk9\nuser: rhel"
+                            }
+                        },
+                        {
+                            "name": "pvc-1",
+                            "persistentVolumeClaim": {
+                                "claimName": "the-claim-is-persistent"
+                            }
+                        },
+                        {
+                            "name": "pvc-2",
+                            "persistentVolumeClaim": {
+                                "claimName": "the-claim-is-too-persistent"
                             }
                         }
                     ]


### PR DESCRIPTION
### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-22579
### Description of changes
- Added relationships VM --_attachedTo_--> PVC,
- VM --_attachedTo_--> DV,
- VMIM --_migrationOf_--> VMI

Special logic had to be introduced to handle JSONPATH extracting nested slices, this should be eventually generalized with the configurable search collection