### PR TITLE
ACM-30764 - introduce datatypebool

### DIFF
--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -840,7 +840,15 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 						node.Properties[prop.Name] = interfaceSlice
 					}
 				} else {
-					node.Properties[prop.Name] = val
+					if b, ok := val.(bool); ok { // if value is a bool, store as bool if stated, else as a string
+						if prop.DataType == DataTypeBool {
+							node.Properties[prop.Name] = b
+						} else {
+							node.Properties[prop.Name] = strconv.FormatBool(b)
+						}
+					} else {
+						node.Properties[prop.Name] = val
+					}
 				}
 			}
 		} else {

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -840,12 +840,8 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 						node.Properties[prop.Name] = interfaceSlice
 					}
 				} else {
-					if b, ok := val.(bool); ok { // if value is a bool, store as bool if stated, else as a string
-						if prop.DataType == DataTypeBool {
-							node.Properties[prop.Name] = b
-						} else {
-							node.Properties[prop.Name] = strconv.FormatBool(b)
-						}
+					if b, ok := val.(bool); ok { // convert bool to string
+						node.Properties[prop.Name] = strconv.FormatBool(b)
 					} else {
 						node.Properties[prop.Name] = val
 					}

--- a/pkg/transforms/cronjob.go
+++ b/pkg/transforms/cronjob.go
@@ -11,6 +11,7 @@ Copyright (c) 2020 Red Hat, Inc.
 package transforms
 
 import (
+	"strconv"
 	"time"
 
 	v1 "k8s.io/api/batch/v1beta1"
@@ -33,9 +34,9 @@ func CronJobResourceBuilder(c *v1.CronJob) *CronJobResource {
 	if c.Status.LastScheduleTime != nil {
 		node.Properties["lastSchedule"] = c.Status.LastScheduleTime.UTC().Format(time.RFC3339)
 	}
-	node.Properties["suspend"] = false
+	node.Properties["suspend"] = "false"
 	if c.Spec.Suspend != nil {
-		node.Properties["suspend"] = *c.Spec.Suspend
+		node.Properties["suspend"] = strconv.FormatBool(*c.Spec.Suspend)
 	}
 
 	return &CronJobResource{node: node}

--- a/pkg/transforms/cronjob_test.go
+++ b/pkg/transforms/cronjob_test.go
@@ -30,7 +30,7 @@ func TestTransformCronJob(t *testing.T) {
 	AssertEqual("active", node.Properties["active"], int64(0), t)
 	AssertEqual("lastSchedule", node.Properties["lastSchedule"], date.UTC().Format(time.RFC3339), t)
 	AssertEqual("schedule", node.Properties["schedule"], "30 23 * * *", t)
-	AssertEqual("suspend", node.Properties["suspend"], false, t)
+	AssertEqual("suspend", node.Properties["suspend"], "false", t)
 }
 
 func TestCronJobBuildEdges(t *testing.T) {

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -20,7 +20,6 @@ type ExtractEdge struct {
 type DataType string
 
 const (
-	DataTypeBool      DataType = "bool"
 	DataTypeBytes     DataType = "bytes"
 	DataTypeSlice     DataType = "slice"
 	DataTypeString    DataType = "string"
@@ -216,7 +215,7 @@ var defaultTransformConfig = map[string]ResourceConfig{
 			{Name: "ready", JSONPath: `{.status.conditions[?(@.type=='Ready')].status}`},
 			{Name: "runStrategy", JSONPath: `{.spec.runStrategy}`},
 			{Name: "status", JSONPath: `{.status.printableStatus}`},
-			{Name: "_specRunning", JSONPath: `{.spec.running}`, DataType: DataTypeBool},
+			{Name: "_specRunning", JSONPath: `{.spec.running}`},
 			{Name: "_specRunStrategy", JSONPath: `{.spec.runStrategy}`},
 			{Name: "workload", JSONPath: `{.spec.template.metadata.annotations.\vm\.kubevirt\.io/workload}`},
 		},

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -20,6 +20,7 @@ type ExtractEdge struct {
 type DataType string
 
 const (
+	DataTypeBool      DataType = "bool"
 	DataTypeBytes     DataType = "bytes"
 	DataTypeSlice     DataType = "slice"
 	DataTypeString    DataType = "string"
@@ -215,7 +216,7 @@ var defaultTransformConfig = map[string]ResourceConfig{
 			{Name: "ready", JSONPath: `{.status.conditions[?(@.type=='Ready')].status}`},
 			{Name: "runStrategy", JSONPath: `{.spec.runStrategy}`},
 			{Name: "status", JSONPath: `{.status.printableStatus}`},
-			{Name: "_specRunning", JSONPath: `{.spec.running}`},
+			{Name: "_specRunning", JSONPath: `{.spec.running}`, DataType: DataTypeBool},
 			{Name: "_specRunStrategy", JSONPath: `{.spec.runStrategy}`},
 			{Name: "workload", JSONPath: `{.spec.template.metadata.annotations.\vm\.kubevirt\.io/workload}`},
 		},

--- a/pkg/transforms/genericResource_test.go
+++ b/pkg/transforms/genericResource_test.go
@@ -244,7 +244,7 @@ func Test_genericResourceFromConfigVMSnapshot(t *testing.T) {
 	AssertEqual("ready", node.Properties["ready"], "True", t)
 	AssertEqual("_conditionReadyReason", node.Properties["_conditionReadyReason"], "Operation complete", t)
 	AssertEqual("phase", node.Properties["phase"], "Succeeded", t)
-	AssertEqual("readyToUse", node.Properties["readyToUse"], true, t)
+	AssertEqual("readyToUse", node.Properties["readyToUse"], "true", t)
 	AssertEqual("sourceName", node.Properties["sourceName"], "centos7-gray-owl-35", t)
 	AssertEqual("sourceKind", node.Properties["sourceKind"], "VirtualMachine", t)
 	AssertDeepEqual("indications", node.Properties["indications"], []interface{}{"Online", "NoGuestAgent"}, t)
@@ -252,7 +252,6 @@ func Test_genericResourceFromConfigVMSnapshot(t *testing.T) {
 		"Ready":       "True",
 		"Progressing": "False",
 	}, t)
-
 }
 
 func Test_genericResourceFromConfigVMRestore(t *testing.T) {
@@ -269,7 +268,7 @@ func Test_genericResourceFromConfigVMRestore(t *testing.T) {
 	// Verify properties defined in the transform config
 	AssertEqual("ready", node.Properties["ready"], "True", t)
 	AssertEqual("_conditionReadyReason", node.Properties["_conditionReadyReason"], "Operation complete", t)
-	AssertEqual("complete", node.Properties["complete"], true, t)
+	AssertEqual("complete", node.Properties["complete"], "true", t)
 	AssertEqual("targetApiGroup", node.Properties["targetApiGroup"], "kubevirt.io", t)
 	AssertEqual("targetName", node.Properties["targetName"], "centos7-gray-owl-35", t)
 	AssertEqual("targetKind", node.Properties["targetKind"], "VirtualMachine", t)
@@ -329,7 +328,7 @@ func Test_genericResourceFromConfigStorageClass(t *testing.T) {
 	AssertEqual("created", node.Properties["created"], "2025-03-11T10:24:44Z", t)
 
 	// Verify properties defined in the transform config
-	AssertEqual("allowVolumeExpansion", node.Properties["allowVolumeExpansion"], true, t)
+	AssertEqual("allowVolumeExpansion", node.Properties["allowVolumeExpansion"], "true", t)
 	AssertEqual("provisioner", node.Properties["provisioner"], "ebs.csi.aws.com", t)
 	AssertEqual("reclaimPolicy", node.Properties["reclaimPolicy"], "Delete", t)
 	AssertEqual("volumeBindingMode", node.Properties["volumeBindingMode"], "WaitForFirstConsumer", t)
@@ -512,8 +511,8 @@ func Test_genericResourceFromConfigMigrationPolicy(t *testing.T) {
 	AssertEqual("created", node.Properties["created"], "2025-12-15T12:00:00Z", t)
 
 	// Verify properties defined in the transform config
-	AssertEqual("allowAutoConverge", node.Properties["allowAutoConverge"], true, t)
-	AssertEqual("allowPostCopy", node.Properties["allowPostCopy"], false, t)
+	AssertEqual("allowAutoConverge", node.Properties["allowAutoConverge"], "true", t)
+	AssertEqual("allowPostCopy", node.Properties["allowPostCopy"], "false", t)
 	AssertEqual("bandwidthPerMigration", node.Properties["bandwidthPerMigration"], int64(67108864), t)
 	AssertEqual("completionTimeoutPerGiB", node.Properties["completionTimeoutPerGiB"], int64(120), t)
 	AssertDeepEqual("annotation", node.Properties["annotation"], map[string]string{

--- a/pkg/transforms/genericResource_test.go
+++ b/pkg/transforms/genericResource_test.go
@@ -166,7 +166,7 @@ func Test_genericResourceFromConfigVM(t *testing.T) {
 	AssertEqual("runStrategy", node.Properties["runStrategy"], "always", t)
 	AssertEqual("status", node.Properties["status"], "Running", t)
 	AssertEqual("workload", node.Properties["workload"], "server", t)
-	AssertEqual("_specRunning", node.Properties["_specRunning"], true, t)
+	AssertEqual("_specRunning", node.Properties["_specRunning"], "true", t)
 	AssertEqual("_specRunStrategy", node.Properties["_specRunStrategy"], "always", t)
 }
 

--- a/pkg/transforms/policy.go
+++ b/pkg/transforms/policy.go
@@ -13,6 +13,7 @@ package transforms
 import (
 	"encoding/json"
 	"slices"
+	"strconv"
 	"strings"
 
 	policy "github.com/stolostron/governance-policy-propagator/api/v1"
@@ -37,7 +38,7 @@ func PolicyResourceBuilder(p *policy.Policy) *PolicyResource {
 	apiGroupVersion(p.TypeMeta, &node) // add kind, apigroup and version
 	// Extract the properties specific to this type
 	node.Properties["remediationAction"] = string(p.Spec.RemediationAction)
-	node.Properties["disabled"] = p.Spec.Disabled
+	node.Properties["disabled"] = strconv.FormatBool(p.Spec.Disabled)
 	node.Properties["numRules"] = len(p.Spec.PolicyTemplates)
 	// For the root policy (on hub, in non cluster ns), it doesn't have an overall status. it has status per cluster.
 	// On managed cluster, compliance is reported by status.compliant
@@ -83,7 +84,8 @@ func getPolicyCommonProperties(c *unstructured.Unstructured, node Node) Node {
 
 	node.Properties["remediationAction"], _, _ = unstructured.NestedString(c.Object, "spec", "remediationAction")
 
-	node.Properties["disabled"], _, _ = unstructured.NestedBool(c.Object, "spec", "disabled")
+	disabled, _, _ := unstructured.NestedBool(c.Object, "spec", "disabled")
+	node.Properties["disabled"] = strconv.FormatBool(disabled)
 
 	return node
 }

--- a/pkg/transforms/policy_test.go
+++ b/pkg/transforms/policy_test.go
@@ -26,7 +26,7 @@ func TestTransformPolicy(t *testing.T) {
 
 	// Test only the fields that exist in policy - the common test will test the other bits
 	AssertEqual("remediationAction", node.Properties["remediationAction"], "enforce", t)
-	AssertEqual("disabled", node.Properties["disabled"], false, t)
+	AssertEqual("disabled", node.Properties["disabled"], "false", t)
 	AssertEqual("numRules", node.Properties["numRules"], 1, t)
 	assert.Len(t, node.Properties["annotation"], 3, "expected 3 annotations on the policy")
 }
@@ -47,7 +47,7 @@ func TestTransformConfigPolicy(t *testing.T) {
 	AssertEqual("compliant", node.Properties["compliant"], "NonCompliant", t)
 	AssertEqual("remediationAction", node.Properties["remediationAction"], "inform", t)
 	AssertEqual("severity", node.Properties["severity"], "low", t)
-	AssertEqual("disabled", node.Properties["disabled"], false, t)
+	AssertEqual("disabled", node.Properties["disabled"], "false", t)
 	AssertEqual("_isExternal", node.Properties["_isExternal"], true, t)
 	obj1 := `{"v":"v1","k":"Namespace","n":"default"}`
 	obj2 := `{"v":"v1","k":"Namespace","n":"nonexistent"}`
@@ -73,7 +73,7 @@ func TestTransformOperatorPolicy(t *testing.T) {
 	AssertEqual("severity", node.Properties["severity"], "critical", t)
 	AssertEqual("deploymentAvailable", node.Properties["deploymentAvailable"], false, t)
 	AssertEqual("upgradeAvailable", node.Properties["upgradeAvailable"], true, t)
-	AssertEqual("disabled", node.Properties["disabled"], false, t)
+	AssertEqual("disabled", node.Properties["disabled"], "false", t)
 	AssertEqual("_isExternal", node.Properties["_isExternal"], false, t)
 
 	objs := []relatedObject{{
@@ -114,7 +114,7 @@ func TestTransformCertPolicy(t *testing.T) {
 	// Test only the fields that exist in policy - the common test will test the other bits
 	AssertEqual("compliant", node.Properties["compliant"], "NonCompliant", t)
 	AssertEqual("severity", node.Properties["severity"], "low", t)
-	AssertEqual("disabled", node.Properties["disabled"], false, t)
+	AssertEqual("disabled", node.Properties["disabled"], "false", t)
 	AssertEqual("_isExternal", node.Properties["_isExternal"], true, t)
 	obj := `{"v":"v1","k":"Secret","ns":"default","n":"sample-secret"}`
 	AssertEqual("relObjs", node.GetMetadata("relObjs"), "["+obj+"]", t)


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-30764

### Description of changes
- Added datatype DataTypeBool and store bools as string as the API queries them as if they were strings. We store status condition bools as string, so despite upper vs lowercase when comparing status conditions to these bools, we retain consistency. The only real bool values we retain are _ prefixed and not directly queried via API.
