### PR TITLE
Fixes matchLabels when resource doesn't have any labels

### DIFF
--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -711,7 +711,11 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 
 	for _, prop := range transformConfig.properties {
 		// Skip if property has matchLabel condition and node doesn't contain matching label
-		if prop.matchLabel != "" && node.Properties["label"] != nil {
+		if prop.matchLabel != "" {
+			// Skip if resource doesn't have labels, it won't match the matchLabel.
+			if node.Properties["label"] == nil {
+				continue
+			}
 			if _, ok := node.Properties["label"].(map[string]string)[prop.matchLabel]; !ok {
 				continue
 			}

--- a/pkg/transforms/common_test.go
+++ b/pkg/transforms/common_test.go
@@ -381,3 +381,25 @@ func TestGetConditionsUnmarshalFail(t *testing.T) {
 	assert.Error(t, err, "Expected error when unmarshaling fails")
 	assert.Nil(t, result, "Expected nil result when unmarshal error occurs")
 }
+
+func Test_genericResourceFromConfigMapNoLabelsToMatchMatchLabel(t *testing.T) {
+	config.Cfg.DeployedInHub = false // temporarily set to false else _hubClusterResource gets appended during full test suite
+	defer func() {
+		config.Cfg.DeployedInHub = true
+	}()
+	var r unstructured.Unstructured
+	UnmarshalFile("configmap-two.json", &r, t)
+	// when matchLabel checks against nil labels we skip the configured additional ExtractProperties
+	r.SetLabels(nil)
+	node := GenericResourceBuilder(&r).BuildNode()
+
+	// Verify common properties
+	AssertEqual("name", node.Properties["name"], "app-config", t)
+	AssertEqual("kind", node.Properties["kind"], "ConfigMap", t)
+	AssertEqual("created", node.Properties["created"], "2026-01-05T14:27:31Z", t)
+	AssertEqual("apiversion", node.Properties["apiversion"], "v1", t)
+	AssertEqual("namespace", node.Properties["namespace"], "default", t)
+
+	// Verify that there's no more indexed properties than the common ones
+	assert.Equal(t, 5, len(node.Properties))
+}


### PR DESCRIPTION
### Related Issue

The `matchLabel` logic was incorrect for the case where the resource doesn't have any labels.

### Description of changes
- Fixes the `matchLabel` code for the case where the resource doesn't have any labels.
