### PR TITLE
ACM-33434: CRD discovery sync was not using interval value from config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,7 @@ const (
 	DEFAULT_POD_NAMESPACE      = "open-cluster-management"
 	DEFAULT_HEARTBEAT_MS       = 300000 // 5 min
 	DEFAULT_MAX_BACKOFF_MS     = 600000 // 10 min
-	DEFAULT_REDISCOVER_RATE_MS = 60000 // 1 min
+	DEFAULT_REDISCOVER_RATE_MS = 60000  // 1 min
 	DEFAULT_REPORT_RATE_MS     = 5000   // 5 seconds
 	DEFAULT_RETRY_JITTER_MS    = 5000   // 5 seconds
 	DEFAULT_RUNTIME_MODE       = "production"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,7 @@ const (
 	DEFAULT_POD_NAMESPACE      = "open-cluster-management"
 	DEFAULT_HEARTBEAT_MS       = 300000 // 5 min
 	DEFAULT_MAX_BACKOFF_MS     = 600000 // 10 min
-	DEFAULT_REDISCOVER_RATE_MS = 120000 // 2 min
+	DEFAULT_REDISCOVER_RATE_MS = 60000 // 1 min
 	DEFAULT_REPORT_RATE_MS     = 5000   // 5 seconds
 	DEFAULT_RETRY_JITTER_MS    = 5000   // 5 seconds
 	DEFAULT_RUNTIME_MODE       = "production"
@@ -58,6 +58,7 @@ type Config struct {
 	KubeConfig                    string       `env:"KUBECONFIG"`                      // Local kubeconfig path
 	MaxBackoffMS                  int          `env:"MAX_BACKOFF_MS"`                  // Maximum backoff in ms to wait after error
 	PodNamespace                  string       `env:"POD_NAMESPACE"`                   // The namespace of this pod
+	RediscoverRateMS              int          `env:"REDISCOVER_RATE_MS"`              // Interval(ms) between CRD discovery syncs
 	RetryJitterMS                 int          `env:"RETRY_JITTER_MS"`                 // Random jitter added to backoff wait.
 	ReportRateMS                  int          `env:"REPORT_RATE_MS"`                  // Interval(ms) to send changes to the aggregator
 	RuntimeMode                   string       `env:"RUNTIME_MODE"`                    // Running mode (development or production)
@@ -102,6 +103,7 @@ func InitConfig() {
 
 	setDefaultInt(&Cfg.HeartbeatMS, "HEARTBEAT_MS", DEFAULT_HEARTBEAT_MS)
 	setDefaultInt(&Cfg.MaxBackoffMS, "MAX_BACKOFF_MS", DEFAULT_MAX_BACKOFF_MS)
+	setDefaultInt(&Cfg.RediscoverRateMS, "REDISCOVER_RATE_MS", DEFAULT_REDISCOVER_RATE_MS)
 	setDefaultInt(&Cfg.ReportRateMS, "REPORT_RATE_MS", DEFAULT_REPORT_RATE_MS)
 	setDefaultInt(&Cfg.RetryJitterMS, "RETRY_JITTER_MS", DEFAULT_RETRY_JITTER_MS)
 

--- a/pkg/informer/runInformers.go
+++ b/pkg/informer/runInformers.go
@@ -511,7 +511,7 @@ func RunInformers(
 	close(initialized)
 
 	lastSynced := time.Now()
-	minBetweenSyncs := 5 * time.Second
+	minBetweenSyncs := time.Duration(config.Cfg.RediscoverRateMS) * time.Millisecond
 
 	// Keep the informers synchronized when CRDs are added or deleted in the cluster.
 	for {

--- a/pkg/informer/runInformers.go
+++ b/pkg/informer/runInformers.go
@@ -536,7 +536,8 @@ func RunInformers(
 			return
 		}
 
-		// Add up to a 5 second delay to account for things such as a new operator adding multiple CRDs.
+		// Enforce a minimum delay between syncs (configurable via REDISCOVER_RATE_MS, default 60s)
+		// to avoid excessive API server calls when multiple CRDs are added or deleted in quick succession.
 		sinceLastSync := time.Since(lastSynced)
 
 		if sinceLastSync < minBetweenSyncs {


### PR DESCRIPTION
## Summary
- Reduce the discovery client requests to sync CRDs.
- Added `REDISCOVER_RATE_MS` env variable to control the minimum interval between CRD discovery syncs
- Default changed from 5 seconds (hardcoded) to 60 seconds
- Updated `DEFAULT_REDISCOVER_RATE_MS` constant (was already defined but unused) to reflect the new default


Resolves: [ACM-33434](https://redhat.atlassian.net/browse/ACM-33434)

🤖 Assisted by [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rediscovery interval can now be configured via environment variable to suit different deployment needs.

* **Improvements**
  * Default rediscovery interval shortened from 2 minutes to 1 minute for faster discovery cycles and quicker reaction to changes.
  * Runtime uses the configurable interval to throttle discovery attempts, reducing hard-coded timing and allowing operational tuning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ACM-33434]: https://redhat.atlassian.net/browse/ACM-33434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ