### PR TITLE
ACM-33435: Reduce edge computation - incremental every 5s, full resync every 60s

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,12 +32,13 @@ const (
 	DEFAULT_AGGREGATOR_PORT    = "3010"
 	DEFAULT_CLUSTER_NAME       = "local-cluster"
 	DEFAULT_POD_NAMESPACE      = "open-cluster-management"
-	DEFAULT_HEARTBEAT_MS       = 300000 // 5 min
-	DEFAULT_MAX_BACKOFF_MS     = 600000 // 10 min
-	DEFAULT_REDISCOVER_RATE_MS = 120000 // 2 min
-	DEFAULT_REPORT_RATE_MS     = 5000   // 5 seconds
-	DEFAULT_RETRY_JITTER_MS    = 5000   // 5 seconds
-	DEFAULT_RUNTIME_MODE       = "production"
+	DEFAULT_HEARTBEAT_MS        = 300000 // 5 min
+	DEFAULT_MAX_BACKOFF_MS      = 600000 // 10 min
+	DEFAULT_REDISCOVER_RATE_MS  = 120000 // 2 min
+	DEFAULT_REPORT_RATE_MS      = 5000   // 5 seconds
+	DEFAULT_RETRY_JITTER_MS     = 5000   // 5 seconds
+	DEFAULT_RUNTIME_MODE        = "production"
+	DEFAULT_EDGE_RESYNC_RATE_MS = 60000 // 1 min
 )
 
 // Configuration options for the search-collector.
@@ -52,6 +53,7 @@ type Config struct {
 	CollectStatusConditions       bool         `env:"COLLECT_STATUS_CONDITIONS"`       // Collect all status condition types and values if present
 	ClusterName                   string       `env:"CLUSTER_NAME"`                    // The name of of the cluster where this pod is running
 	DeployedInHub                 bool         `env:"DEPLOYED_IN_HUB"`                 // Tracks if deployed in the Hub or Managed cluster
+	EdgeResyncRateMS              int          `env:"EDGE_RESYNC_RATE_MS"`             // Interval(ms) for full edge recomputation to catch missed incremental edges
 	FeatureConfigurableCollection bool         `env:"FEATURE_CONFIGURABLE_COLLECTION"` // Enable configurable collection feature to extend transforms config
 	HeartbeatMS                   int          `env:"HEARTBEAT_MS"`                    // Interval(ms) to send empty payload to ensure connection
 	HTTPTimeout                   int          `env:"HTTP_TIMEOUT"`                    // Timeout for http server connections. Default: 5 min
@@ -100,6 +102,7 @@ func InitConfig() {
 		setDefault(&Cfg.AggregatorURL, "AGGREGATOR_URL", DEFAULT_AGGREGATOR_URL)
 	}
 
+	setDefaultInt(&Cfg.EdgeResyncRateMS, "EDGE_RESYNC_RATE_MS", DEFAULT_EDGE_RESYNC_RATE_MS)
 	setDefaultInt(&Cfg.HeartbeatMS, "HEARTBEAT_MS", DEFAULT_HEARTBEAT_MS)
 	setDefaultInt(&Cfg.MaxBackoffMS, "MAX_BACKOFF_MS", DEFAULT_MAX_BACKOFF_MS)
 	setDefaultInt(&Cfg.ReportRateMS, "REPORT_RATE_MS", DEFAULT_REPORT_RATE_MS)

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -155,48 +155,33 @@ func (r *Reconciler) Diff() Diff {
 		newEdges = r.incrementalEdges()
 	}
 
-	// TODO combine the following 2 loops?
-
-	// Find elements that are in both new and old, and delete them from previous. After this, only the edges
-	// to be deleted will remain in previous.
-	// TODO shortcut this by checking whether one of the src/dest doesn't exist any more
-	// (could delete the whole map in the case of srcUID missing)
+	// Edges added: present in newEdges but absent from previousEdges.
 	for srcUID, destMap := range newEdges {
 		for destUID, newEdge := range destMap {
-			// If it's present in this loop it's obviously in the new set, so check the old.
-			if _, ok := r.previousEdges[srcUID][destUID]; ok {
-				delete(r.previousEdges[srcUID], destUID)
-			} else { // If it's in the new and NOT the old, it's an edge that's been added
+			if _, ok := r.previousEdges[srcUID][destUID]; !ok {
 				ret.AddEdges = append(ret.AddEdges, newEdge)
 			}
 		}
 	}
 
-	// Now go back through the remains of the previous and coerce to slice of edges to be deleted
+	// Edges deleted: present in previousEdges but absent from newEdges, and whose source/dest
+	// node is not already in ret.DeleteNodes (the indexer removes edges automatically when a
+	// node is deleted, so we only need to send explicit DeleteEdges for orphaned edges).
 	for srcUID, destMap := range r.previousEdges {
-		srcDeleted := false // flag to check if the sourceNode is in ret.DeleteNodes
 		for destUID, oldEdge := range destMap {
-			destDeleted := false // flag to check if the destNode is in ret.DeleteNodes
-			// Loop through ret.DeleteNodes and check if the source or destination nodes are up for delete.
-			// Since the associated edges gets deleted automatically when the node is deleted,
-			// we won't add the edges to ret.DeleteEdges
+			if _, ok := newEdges[srcUID][destUID]; ok {
+				continue // edge still exists
+			}
+			srcDeleted, destDeleted := false, false
 			for _, delNode := range ret.DeleteNodes {
 				if srcUID == delNode.UID {
-					// If srcUID is in ret.DeleteNodes, delete the whole sourceUID map from previousEdges and break
-					delete(r.previousEdges, srcUID)
 					srcDeleted = true
 					break
 				} else if destUID == delNode.UID {
-					// If the srcUID is in ret.DeleteNodes, delete the edge from previousEdges
-					delete(r.previousEdges[srcUID], destUID)
 					destDeleted = true
 				}
 			}
-			if srcDeleted {
-				break //break out of the inner for loop since the whole sourceUID map is already deleted
-			}
 			if !srcDeleted && !destDeleted {
-				//Add the edge to be deleted only if the source and destination nodes are not in ret.DeleteNodes
 				ret.DeleteEdges = append(ret.DeleteEdges, oldEdge)
 			}
 		}
@@ -263,26 +248,64 @@ func (r *Reconciler) incrementalEdges() map[string]map[string]tr.Edge {
 		ByKindNamespaceName: nodeTripleMap(r.currentNodes),
 	}
 
-	// Deep-copy previousEdges as the starting point so we don't mutate the stored state.
+	// Start with shallow references to every bucket in previousEdges. Buckets are deep-copied
+	// the first time they are modified (copy-on-write), so r.previousEdges is never mutated.
+	// This avoids the O(|currentEdges|) full deep-copy and only pays for the buckets touched
+	// by diffNodes — typically O(|diffNodes|) in the common case.
 	newEdges := make(map[string]map[string]tr.Edge, len(r.previousEdges))
 	for srcUID, destMap := range r.previousEdges {
-		newEdges[srcUID] = make(map[string]tr.Edge, len(destMap))
-		for destUID, edge := range destMap {
-			newEdges[srcUID][destUID] = edge
+		newEdges[srcUID] = destMap // shallow reference
+	}
+
+	// Track which buckets have already been independently copied.
+	cloned := make(map[string]bool, len(r.diffNodes))
+
+	// ensureCloned deep-copies a bucket on its first write so we never modify a shared reference.
+	ensureCloned := func(srcUID string) {
+		if cloned[srcUID] {
+			return
+		}
+		if existing, ok := newEdges[srcUID]; ok {
+			copied := make(map[string]tr.Edge, len(existing))
+			for k, v := range existing {
+				copied[k] = v
+			}
+			newEdges[srcUID] = copied
+		}
+		cloned[srcUID] = true
+	}
+
+	// Apply Application-first ordering from diffNodes, matching allEdges() behavior.
+	// This ensures _hostingApplication metadata is populated before Subscription edges are built
+	// when both Application and Subscription nodes are updated in the same diff cycle.
+	var appUIDs, otherUIDs []string
+	for uid, ne := range r.diffNodes {
+		if kind, _ := ne.Properties["kind"].(string); kind == "Application" { //nolint:staticcheck // "could remove embedded field 'Node' from selector"
+			appUIDs = append(appUIDs, uid)
+		} else {
+			otherUIDs = append(otherUIDs, uid)
 		}
 	}
 
-	for uid, ne := range r.diffNodes {
-		// Remove all outgoing edges FROM this node; they will be re-added below if the node still exists.
+	for _, uid := range append(appUIDs, otherUIDs...) {
+		ne := r.diffNodes[uid]
+
+		// Remove outgoing edges FROM this node; it will be recomputed below or is being deleted.
 		delete(newEdges, uid)
+		cloned[uid] = true // bucket is gone; any new writes will create a fresh map
 
 		switch ne.Operation {
 		case tr.Delete:
-			// Remove all incoming edges TO this deleted node from every source.
-			for srcUID := range newEdges {
+			// Remove all incoming edges TO this deleted node from every source bucket.
+			for srcUID, destMap := range newEdges {
+				if _, ok := destMap[uid]; !ok {
+					continue
+				}
+				ensureCloned(srcUID)
 				delete(newEdges[srcUID], uid)
 				if len(newEdges[srcUID]) == 0 {
 					delete(newEdges, srcUID)
+					delete(cloned, srcUID)
 				}
 			}
 		default: // Create or Update
@@ -292,6 +315,9 @@ func (r *Reconciler) incrementalEdges() map[string]map[string]tr.Edge {
 				for _, edge := range edges {
 					if _, ok := newEdges[edge.SourceUID]; !ok {
 						newEdges[edge.SourceUID] = make(map[string]tr.Edge)
+						cloned[edge.SourceUID] = true
+					} else {
+						ensureCloned(edge.SourceUID)
 					}
 					newEdges[edge.SourceUID][edge.DestUID] = edge
 				}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -14,8 +14,10 @@ package reconciler
 import (
 	"reflect"
 	"sync"
+	"time"
 
 	lru "github.com/golang/groupcache/lru"
+	"github.com/stolostron/search-collector/pkg/config"
 	"github.com/stolostron/search-collector/pkg/metrics"
 	tr "github.com/stolostron/search-collector/pkg/transforms"
 	"k8s.io/klog/v2"
@@ -82,6 +84,8 @@ type Reconciler struct {
 	previousEdges map[string]map[string]tr.Edge // Keyed by source then dest so we can quickly compare the new list
 	totalEdges    int                           // Save the total count as we build to avoid looping when needed
 
+	lastFullEdgeSync int64 // Unix timestamp of the last full allEdges() call within Diff()
+
 	Input       chan tr.NodeEvent
 	mutex       sync.Mutex // Used to protect currentState and diffState as they are accessed by multiple goroutines
 	purgedNodes *lru.Cache // Tracks deleted nodes, so the reconciler can prevent out of order processing of events
@@ -135,8 +139,21 @@ func (r *Reconciler) Diff() Diff {
 		}
 	}
 
-	// Fill out edges
-	newEdges := r.allEdges()
+	// Hybrid edge computation: use incrementalEdges() every diff cycle for CPU efficiency,
+	// and fall back to allEdges() periodically (EDGE_RESYNC_RATE_MS, default 60s) to catch
+	// edges that the incremental approach misses — for example, a Service whose selector
+	// matches a Pod whose labels were updated, where the Service is not in diffNodes.
+	// Missed edges are corrected within one resync interval; only the delta is sent to the
+	// indexer (no ClearAll / complete payload).
+	var newEdges map[string]map[string]tr.Edge
+	edgeResyncInterval := int64(config.Cfg.EdgeResyncRateMS / 1000)
+	if time.Now().Unix()-r.lastFullEdgeSync >= edgeResyncInterval {
+		klog.V(4).Info("Periodic full edge recomputation to catch any missed incremental edges.")
+		newEdges = r.allEdges()
+		r.lastFullEdgeSync = time.Now().Unix()
+	} else {
+		newEdges = r.incrementalEdges()
+	}
 
 	// TODO combine the following 2 loops?
 
@@ -229,6 +246,66 @@ func (r *Reconciler) Complete() CompleteState {
 	ret.TotalNodes = len(r.currentNodes)
 	ret.TotalEdges = r.totalEdges
 	return ret
+}
+
+// incrementalEdges builds an updated edge map by starting from previousEdges and recomputing
+// edges only for nodes in diffNodes. This is O(|diffNodes|) instead of O(N) for a full
+// recomputation, making it suitable for the Diff() hot path between periodic full resyncs.
+//
+// Trade-off: edges from unchanged nodes that reference a node whose properties changed
+// (e.g. a Service whose selector now matches a Pod with updated labels) will not be updated
+// until the next periodic allEdges() call (controlled by EDGE_RESYNC_RATE_MS, default 60s).
+func (r *Reconciler) incrementalEdges() map[string]map[string]tr.Edge {
+	klog.V(4).Info("Reconciler is updating edges incrementally for changed nodes.")
+
+	ns := tr.NodeStore{
+		ByUID:               r.currentNodes,
+		ByKindNamespaceName: nodeTripleMap(r.currentNodes),
+	}
+
+	// Deep-copy previousEdges as the starting point so we don't mutate the stored state.
+	newEdges := make(map[string]map[string]tr.Edge, len(r.previousEdges))
+	for srcUID, destMap := range r.previousEdges {
+		newEdges[srcUID] = make(map[string]tr.Edge, len(destMap))
+		for destUID, edge := range destMap {
+			newEdges[srcUID][destUID] = edge
+		}
+	}
+
+	for uid, ne := range r.diffNodes {
+		// Remove all outgoing edges FROM this node; they will be re-added below if the node still exists.
+		delete(newEdges, uid)
+
+		switch ne.Operation {
+		case tr.Delete:
+			// Remove all incoming edges TO this deleted node from every source.
+			for srcUID := range newEdges {
+				delete(newEdges[srcUID], uid)
+				if len(newEdges[srcUID]) == 0 {
+					delete(newEdges, srcUID)
+				}
+			}
+		default: // Create or Update
+			if edgeFunc, ok := r.edgeFuncs[uid]; ok {
+				edges := edgeFunc(ns)
+				edges = append(edges, tr.CommonEdges(uid, ns)...)
+				for _, edge := range edges {
+					if _, ok := newEdges[edge.SourceUID]; !ok {
+						newEdges[edge.SourceUID] = make(map[string]tr.Edge)
+					}
+					newEdges[edge.SourceUID][edge.DestUID] = edge
+				}
+			}
+		}
+	}
+
+	totalEdges := 0
+	for _, destMap := range newEdges {
+		totalEdges += len(destMap)
+	}
+	r.totalEdges = totalEdges
+
+	return newEdges
 }
 
 // Builds all edges for all the nodes.


### PR DESCRIPTION
## Summary

- Replaces the previous O(N) `allEdges()` call on every `Diff()` cycle (every 5s) with a hybrid approach
- `incrementalEdges()` is used each cycle — O(|diffNodes|), only recomputing edges for nodes that changed
- `allEdges()` runs periodically (default every 60s) to correct any edges missed by the incremental path (e.g. a Service whose selector now matches a Pod whose labels changed, where the Service itself was not in diffNodes)
- In both cases only the delta (AddEdges/DeleteEdges) is sent to the indexer — no ClearAll / complete payload triggered
- New `EDGE_RESYNC_RATE_MS` env var (default 60 000 ms) controls the full resync interval

## Trade-off

Edges from unchanged nodes that reference a node whose properties changed may take up to `EDGE_RESYNC_RATE_MS` (default 60s) to appear. This is an accepted trade-off: the common case (edges defined on the changed node itself) is still reflected immediately.

## Test plan

- [ ] `make test` passes locally
- [ ] `make lint` passes locally
- [ ] Verify incremental path is used between resync intervals (klog V4)
- [ ] Verify full resync fires every ~60s and sends any corrected edges as a diff (not a complete payload)

🤖 I'm an AI agent. Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added EDGE_RESYNC_RATE_MS configuration (default 60s) to control how often a full edge resynchronization runs.
  * Edge processing now uses a hybrid strategy: scheduled full resynchronizations at the configured interval plus incremental updates for changed nodes between full cycles, reducing unnecessary full recalculations and improving update efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->