### PR TITLE
ACM-21531 -  CollectorConfig NamespaceSelector

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,18 +26,19 @@ import (
 
 // Out of box defaults
 const (
-	COLLECTOR_API_VERSION      = "2.15.0"
-	DEFAULT_AGGREGATOR_URL     = "https://localhost:3010" // this will be deprecated in the future
-	DEFAULT_AGGREGATOR_HOST    = "https://localhost"
-	DEFAULT_AGGREGATOR_PORT    = "3010"
-	DEFAULT_CLUSTER_NAME       = "local-cluster"
-	DEFAULT_POD_NAMESPACE      = "open-cluster-management"
-	DEFAULT_HEARTBEAT_MS       = 300000 // 5 min
-	DEFAULT_MAX_BACKOFF_MS     = 600000 // 10 min
-	DEFAULT_REDISCOVER_RATE_MS = 60000  // 1 min
-	DEFAULT_REPORT_RATE_MS     = 5000   // 5 seconds
-	DEFAULT_RETRY_JITTER_MS    = 5000   // 5 seconds
-	DEFAULT_RUNTIME_MODE       = "production"
+	COLLECTOR_API_VERSION          = "2.15.0"
+	DEFAULT_AGGREGATOR_URL         = "https://localhost:3010" // this will be deprecated in the future
+	DEFAULT_AGGREGATOR_HOST        = "https://localhost"
+	DEFAULT_AGGREGATOR_PORT        = "3010"
+	DEFAULT_CLUSTER_NAME           = "local-cluster"
+	DEFAULT_POD_NAMESPACE          = "open-cluster-management"
+	DEFAULT_HEARTBEAT_MS           = 300000 // 5 min
+	DEFAULT_MAX_BACKOFF_MS         = 600000 // 10 min
+	DEFAULT_REDISCOVER_RATE_MS     = 60000  // 1 min
+	DEFAULT_REPORT_RATE_MS         = 5000   // 5 seconds
+	DEFAULT_NS_FILTER_CACHE_TTL_MS = 60000  // 1 min
+	DEFAULT_RETRY_JITTER_MS        = 5000   // 5 seconds
+	DEFAULT_RUNTIME_MODE           = "production"
 )
 
 // Configuration options for the search-collector.
@@ -57,6 +58,7 @@ type Config struct {
 	HTTPTimeout                   int          `env:"HTTP_TIMEOUT"`                    // Timeout for http server connections. Default: 5 min
 	KubeConfig                    string       `env:"KUBECONFIG"`                      // Local kubeconfig path
 	MaxBackoffMS                  int          `env:"MAX_BACKOFF_MS"`                  // Maximum backoff in ms to wait after error
+	NSFilterCacheTTLMS            int          `env:"NS_FILTER_CACHE_TTL_MS"`          // TTL(ms) for the namespace filter cache
 	PodNamespace                  string       `env:"POD_NAMESPACE"`                   // The namespace of this pod
 	RediscoverRateMS              int          `env:"REDISCOVER_RATE_MS"`              // Interval(ms) between CRD discovery syncs
 	RetryJitterMS                 int          `env:"RETRY_JITTER_MS"`                 // Random jitter added to backoff wait.
@@ -103,6 +105,7 @@ func InitConfig() {
 
 	setDefaultInt(&Cfg.HeartbeatMS, "HEARTBEAT_MS", DEFAULT_HEARTBEAT_MS)
 	setDefaultInt(&Cfg.MaxBackoffMS, "MAX_BACKOFF_MS", DEFAULT_MAX_BACKOFF_MS)
+	setDefaultInt(&Cfg.NSFilterCacheTTLMS, "NS_FILTER_CACHE_TTL_MS", DEFAULT_NS_FILTER_CACHE_TTL_MS)
 	setDefaultInt(&Cfg.RediscoverRateMS, "REDISCOVER_RATE_MS", DEFAULT_REDISCOVER_RATE_MS)
 	setDefaultInt(&Cfg.ReportRateMS, "REPORT_RATE_MS", DEFAULT_REPORT_RATE_MS)
 	setDefaultInt(&Cfg.RetryJitterMS, "RETRY_JITTER_MS", DEFAULT_RETRY_JITTER_MS)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,7 +36,7 @@ const (
 	DEFAULT_MAX_BACKOFF_MS         = 600000 // 10 min
 	DEFAULT_REDISCOVER_RATE_MS     = 60000  // 1 min
 	DEFAULT_REPORT_RATE_MS         = 5000   // 5 seconds
-	DEFAULT_NS_FILTER_CACHE_TTL_MS = 60000  // 1 min
+	DEFAULT_NS_FILTER_CACHE_TTL_MS = 300000 // 5 min
 	DEFAULT_RETRY_JITTER_MS        = 5000   // 5 seconds
 	DEFAULT_RUNTIME_MODE           = "production"
 )

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -131,7 +131,12 @@ func filterByGlobs(nsList *v1.NamespaceList, nsSelector *v1alpha1.NamespaceSelec
 		if len(nsSelector.Include) > 0 {
 			matched := false
 			for _, pattern := range nsSelector.Include {
-				if ok, _ := filepath.Match(pattern, name); ok {
+				ok, err := filepath.Match(pattern, name)
+				if err != nil {
+					klog.Warningf("Invalid include glob pattern %q: %v", pattern, err)
+					continue
+				}
+				if ok {
 					matched = true
 					break
 				}
@@ -145,7 +150,12 @@ func filterByGlobs(nsList *v1.NamespaceList, nsSelector *v1alpha1.NamespaceSelec
 		if len(nsSelector.Exclude) > 0 {
 			excluded := false
 			for _, pattern := range nsSelector.Exclude {
-				if ok, _ := filepath.Match(pattern, name); ok {
+				ok, err := filepath.Match(pattern, name)
+				if err != nil {
+					klog.Warningf("Invalid exclude glob pattern %q: %v", pattern, err)
+					continue
+				}
+				if ok {
 					excluded = true
 					break
 				}

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -370,6 +370,10 @@ func isNamespaceAllowed(allowedNSMap map[string]bool, namespace string) bool {
 		return true
 	}
 
+	if allowedNSMap == nil { // error in processing allowedNamespaceMap: collect everywhere
+		return true
+	}
+
 	_, ok := allowedNSMap[namespace]
 	return ok
 }

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -6,6 +6,7 @@ package informer
 import (
 	"context"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -20,6 +21,36 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 )
+
+type namespaceCache struct {
+	mu        sync.RWMutex
+	allowed   map[string]bool
+	expiresAt time.Time
+	ttl       time.Duration
+}
+
+// get returns the cached namespace map, refreshing it if the TTL has expired.
+func (c *namespaceCache) get() map[string]bool {
+	c.mu.RLock()
+	if time.Now().Before(c.expiresAt) {
+		defer c.mu.RUnlock()
+		return c.allowed
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Double-check: another goroutine may have refreshed while we waited for the write lock.
+	if time.Now().Before(c.expiresAt) {
+		return c.allowed
+	}
+
+	c.allowed = resolveCollectNamespaces()
+	c.expiresAt = time.Now().Add(c.ttl)
+	return c.allowed
+}
+
+var nsCache = &namespaceCache{ttl: 2 * time.Minute}
 
 // GenericInformer ...
 type GenericInformer struct {
@@ -71,7 +102,7 @@ func (inform *GenericInformer) Run(ctx context.Context) {
 				inform.client = config.GetDynamicClient()
 			}
 
-			collectNamespaces := getCollectNamespaces()
+			collectNamespaces := nsCache.get()
 
 			err := inform.listAndResync(collectNamespaces)
 			if err == nil {
@@ -171,9 +202,9 @@ func filterByGlobs(nsList *v1.NamespaceList, nsSelector *v1alpha1.NamespaceSelec
 	return result
 }
 
-// getCollectNamespaces resolves the CollectorConfig namespaceSelector to a flat list of namespace names.
-// Follows the config-policy-controller pattern: labels first, then include globs, then exclude globs.
-func getCollectNamespaces() map[string]bool {
+// resolveCollectNamespaces fetches the CollectorConfig and resolves the namespaceSelector
+// to a flat map of allowed namespace names. Called by nsCache.get() when the TTL expires.
+func resolveCollectNamespaces() map[string]bool {
 	if !config.Cfg.FeatureConfigurableCollection {
 		return nil
 	}

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -5,17 +5,18 @@ package informer
 
 import (
 	"context"
+	"path/filepath"
 	"sync/atomic"
 	"time"
 
 	"github.com/stolostron/search-collector/pkg/config"
+	"github.com/stolostron/search-v2-operator/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
 )
 
 // GenericInformer ...
@@ -68,10 +69,12 @@ func (inform *GenericInformer) Run(ctx context.Context) {
 				inform.client = config.GetDynamicClient()
 			}
 
-			err := inform.listAndResync()
+			collectNamespaces := getCollectNamespaces()
+
+			err := inform.listAndResync(collectNamespaces)
 			if err == nil {
 				inform.initialized.Store(true)
-				inform.watch(ctx.Done())
+				inform.watch(ctx.Done(), collectNamespaces)
 			}
 		}
 	}
@@ -89,9 +92,110 @@ func newUnstructured(kind, uid string) *unstructured.Unstructured {
 	}
 }
 
+// getCollectNamespaces resolves the CollectorConfig namespaceSelector to a flat list of namespace names.
+// Follows the config-policy-controller pattern: labels first, then include globs, then exclude globs.
+func getCollectNamespaces() map[string]bool {
+	if !config.Cfg.FeatureConfigurableCollection {
+		return nil
+	}
+
+	unstructuredConfig, err := config.GetDynamicClient().Resource(schema.GroupVersionResource{
+		Group:    "search.open-cluster-management.io",
+		Version:  "v1alpha1",
+		Resource: "collectorconfigs",
+	}).Namespace(config.Cfg.PodNamespace).Get(context.Background(), "collector-config", metav1.GetOptions{})
+	if err != nil {
+		klog.Infof("Could not load collector-config resource: %v. Using default config only.", err)
+		return nil
+	}
+
+	var collectorConfig v1alpha1.CollectorConfig
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredConfig.Object, &collectorConfig); err != nil {
+		klog.Warningf("Could not convert collector-config to typed object: %v. Using default config only.", err)
+		return nil
+	}
+
+	// No collectNamespaces or namespaceSelector configured — collect everything
+	if collectorConfig.Spec.CollectNamespaces == nil || collectorConfig.Spec.CollectNamespaces.NamespaceSelector == nil {
+		return nil
+	}
+	nsSelector := collectorConfig.Spec.CollectNamespaces.NamespaceSelector
+
+	// Nothing specified — collect everything
+	if len(nsSelector.Include) == 0 && len(nsSelector.Exclude) == 0 &&
+		len(nsSelector.MatchLabels) == 0 && len(nsSelector.MatchExpressions) == 0 {
+		return nil
+	}
+
+	// Build a label selector from matchLabels and matchExpressions
+	labelSelector := ""
+	if len(nsSelector.MatchLabels) > 0 || len(nsSelector.MatchExpressions) > 0 {
+		ls := &metav1.LabelSelector{
+			MatchLabels:      nsSelector.MatchLabels,
+			MatchExpressions: nsSelector.MatchExpressions,
+		}
+		selector, err := metav1.LabelSelectorAsSelector(ls)
+		if err != nil {
+			klog.Warningf("Error parsing namespace label selector: %v. Skipping label filtering.", err)
+		} else {
+			labelSelector = selector.String()
+		}
+	}
+
+	// List namespaces filtered by labels
+	kubeClient := config.GetKubeClient(config.GetKubeConfig())
+	nsList, err := kubeClient.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		klog.Warningf("Error listing namespaces: %v. Skipping namespace filtering.", err)
+		return nil
+	}
+
+	// Apply include/exclude filepath globs
+	result := make(map[string]bool, 0)
+	for _, ns := range nsList.Items {
+		name := ns.Name
+
+		// Include filter: if include list is specified, namespace must match at least one pattern
+		if len(nsSelector.Include) > 0 {
+			matched := false
+			for _, pattern := range nsSelector.Include {
+				if ok, _ := filepath.Match(pattern, name); ok {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+
+		// Exclude filter: if namespace matches any exclude pattern, skip it
+		if len(nsSelector.Exclude) > 0 {
+			excluded := false
+			for _, pattern := range nsSelector.Exclude {
+				if ok, _ := filepath.Match(pattern, name); ok {
+					excluded = true
+					break
+				}
+			}
+			if excluded {
+				continue
+			}
+		}
+
+		// Add namespace to map that met labels, expressions, includes, and excludes
+		result[name] = true
+	}
+
+	klog.V(3).Infof("Resolved collectNamespaces to %d namespaces: %v", len(result), result)
+	return result
+}
+
 // List current resources and fires ADDED events. Then sync the current state with the previous
 // state and delete any resources that are still in our cache, but no longer exist in the cluster.
-func (inform *GenericInformer) listAndResync() error {
+func (inform *GenericInformer) listAndResync(collectNamespaces map[string]bool) error {
 
 	// Keep track of new resources added to consolidate against the previous state.
 	newResourceIndex := make(map[string]string)
@@ -107,8 +211,12 @@ func (inform *GenericInformer) listAndResync() error {
 			return listError
 		}
 
-		// Add all resources.
+		// Add all resources filtered by namespace
 		for i := range resources.Items {
+			if !isNamespaceAllowed(collectNamespaces, resources.Items[i].GetNamespace()) {
+				continue
+			}
+
 			klog.V(5).Infof("KIND: %s UUID: %s, ResourceVersion: %s",
 				inform.gvr.Resource, resources.Items[i].GetUID(), resources.Items[i].GetResourceVersion())
 			inform.AddFunc(&resources.Items[i])
@@ -140,7 +248,7 @@ func (inform *GenericInformer) listAndResync() error {
 }
 
 // Watch resources and process events.
-func (inform *GenericInformer) watch(stopper <-chan struct{}) {
+func (inform *GenericInformer) watch(stopper <-chan struct{}, collectNamespaces map[string]bool) {
 	watch, watchError := inform.client.Resource(inform.gvr).Watch(context.TODO(), metav1.ListOptions{})
 	if watchError != nil {
 		klog.Warningf("Error watching resources for %s.  Error: %s", inform.gvr.String(), watchError)
@@ -171,6 +279,11 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 						inform.gvr.Resource)
 					continue
 				}
+
+				if !isNamespaceAllowed(collectNamespaces, obj.GetNamespace()) {
+					continue
+				}
+
 				inform.AddFunc(obj)
 				inform.resourceIndex[string(obj.GetUID())] = obj.GetResourceVersion()
 
@@ -183,6 +296,10 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 					continue
 				}
 
+				if !isNamespaceAllowed(collectNamespaces, obj.GetNamespace()) {
+					continue
+				}
+
 				inform.UpdateFunc(nil, obj)
 				inform.resourceIndex[string(obj.GetUID())] = obj.GetResourceVersion()
 
@@ -192,6 +309,10 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 				if !ok {
 					klog.Warningf("Error converting %s event.Object to unstructured.Unstructured on DELETED event",
 						inform.gvr.Resource)
+					continue
+				}
+
+				if !isNamespaceAllowed(collectNamespaces, obj.GetNamespace()) {
 					continue
 				}
 
@@ -221,4 +342,13 @@ func (inform *GenericInformer) WaitUntilInitialized(timeout time.Duration) {
 		}
 		time.Sleep(time.Duration(10) * time.Millisecond)
 	}
+}
+
+func isNamespaceAllowed(allowedNSMap map[string]bool, namespace string) bool {
+	if !config.Cfg.FeatureConfigurableCollection {
+		return true
+	}
+
+	_, ok := allowedNSMap[namespace]
+	return ok
 }

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -11,11 +11,13 @@ import (
 
 	"github.com/stolostron/search-collector/pkg/config"
 	"github.com/stolostron/search-v2-operator/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 )
 
@@ -92,41 +94,7 @@ func newUnstructured(kind, uid string) *unstructured.Unstructured {
 	}
 }
 
-// getCollectNamespaces resolves the CollectorConfig namespaceSelector to a flat list of namespace names.
-// Follows the config-policy-controller pattern: labels first, then include globs, then exclude globs.
-func getCollectNamespaces() map[string]bool {
-	if !config.Cfg.FeatureConfigurableCollection {
-		return nil
-	}
-
-	unstructuredConfig, err := config.GetDynamicClient().Resource(schema.GroupVersionResource{
-		Group:    "search.open-cluster-management.io",
-		Version:  "v1alpha1",
-		Resource: "collectorconfigs",
-	}).Namespace(config.Cfg.PodNamespace).Get(context.Background(), "collector-config", metav1.GetOptions{})
-	if err != nil {
-		klog.Infof("Could not load collector-config resource: %v. Using default config only.", err)
-		return nil
-	}
-
-	var collectorConfig v1alpha1.CollectorConfig
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredConfig.Object, &collectorConfig); err != nil {
-		klog.Warningf("Could not convert collector-config to typed object: %v. Using default config only.", err)
-		return nil
-	}
-
-	// No collectNamespaces or namespaceSelector configured — collect everything
-	if collectorConfig.Spec.CollectNamespaces == nil || collectorConfig.Spec.CollectNamespaces.NamespaceSelector == nil {
-		return nil
-	}
-	nsSelector := collectorConfig.Spec.CollectNamespaces.NamespaceSelector
-
-	// Nothing specified — collect everything
-	if len(nsSelector.Include) == 0 && len(nsSelector.Exclude) == 0 &&
-		len(nsSelector.MatchLabels) == 0 && len(nsSelector.MatchExpressions) == 0 {
-		return nil
-	}
-
+func filterBySelectors(kubeClient kubernetes.Interface, nsSelector *v1alpha1.NamespaceSelector) (*v1.NamespaceList, error) {
 	// Build a label selector from matchLabels and matchExpressions
 	labelSelector := ""
 	if len(nsSelector.MatchLabels) > 0 || len(nsSelector.MatchExpressions) > 0 {
@@ -143,16 +111,18 @@ func getCollectNamespaces() map[string]bool {
 	}
 
 	// List namespaces filtered by labels
-	kubeClient := config.GetKubeClient(config.GetKubeConfig())
 	nsList, err := kubeClient.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {
 		klog.Warningf("Error listing namespaces: %v. Skipping namespace filtering.", err)
-		return nil
+		return nil, nil
 	}
 
-	// Apply include/exclude filepath globs
+	return nsList, nil
+}
+
+func filterByGlobs(nsList *v1.NamespaceList, nsSelector *v1alpha1.NamespaceSelector) map[string]bool {
 	result := make(map[string]bool, 0)
 	for _, ns := range nsList.Items {
 		name := ns.Name
@@ -188,6 +158,53 @@ func getCollectNamespaces() map[string]bool {
 		// Add namespace to map that met labels, expressions, includes, and excludes
 		result[name] = true
 	}
+	return result
+}
+
+// getCollectNamespaces resolves the CollectorConfig namespaceSelector to a flat list of namespace names.
+// Follows the config-policy-controller pattern: labels first, then include globs, then exclude globs.
+func getCollectNamespaces() map[string]bool {
+	if !config.Cfg.FeatureConfigurableCollection {
+		return nil
+	}
+
+	unstructuredConfig, err := config.GetDynamicClient().Resource(schema.GroupVersionResource{
+		Group:    "search.open-cluster-management.io",
+		Version:  "v1alpha1",
+		Resource: "collectorconfigs",
+	}).Namespace(config.Cfg.PodNamespace).Get(context.Background(), "collector-config", metav1.GetOptions{})
+	if err != nil {
+		klog.Infof("Could not load collector-config resource: %v. Using default config only.", err)
+		return nil
+	}
+
+	var collectorConfig v1alpha1.CollectorConfig
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredConfig.Object, &collectorConfig); err != nil {
+		klog.Warningf("Could not convert collector-config to typed object: %v. Using default config only.", err)
+		return nil
+	}
+
+	// No collectNamespaces or namespaceSelector configured — collect everywhere
+	if collectorConfig.Spec.CollectNamespaces == nil || collectorConfig.Spec.CollectNamespaces.NamespaceSelector == nil {
+		return nil
+	}
+	nsSelector := collectorConfig.Spec.CollectNamespaces.NamespaceSelector
+
+	// Nothing specified — collect everywhere
+	if len(nsSelector.Include) == 0 && len(nsSelector.Exclude) == 0 &&
+		len(nsSelector.MatchLabels) == 0 && len(nsSelector.MatchExpressions) == 0 {
+		return nil
+	}
+
+	// List namespaces filtered by labelSelectors and matchExpressions
+	nsList, err := filterBySelectors(config.GetKubeClient(config.GetKubeConfig()), nsSelector)
+	if err != nil {
+		klog.Warningf("Error listing namespaces: %v. Skipping namespace filtering.", err)
+		return nil
+	}
+
+	// Filter namespaces by include and exclude namespace globs
+	result := filterByGlobs(nsList, nsSelector)
 
 	klog.V(3).Infof("Resolved collectNamespaces to %d namespaces: %v", len(result), result)
 	return result

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -116,7 +116,7 @@ func filterBySelectors(kubeClient kubernetes.Interface, nsSelector *v1alpha1.Nam
 	})
 	if err != nil {
 		klog.Warningf("Error listing namespaces: %v. Skipping namespace filtering.", err)
-		return nil, nil
+		return nil, err
 	}
 
 	return nsList, nil
@@ -363,6 +363,10 @@ func (inform *GenericInformer) WaitUntilInitialized(timeout time.Duration) {
 
 func isNamespaceAllowed(allowedNSMap map[string]bool, namespace string) bool {
 	if !config.Cfg.FeatureConfigurableCollection {
+		return true
+	}
+
+	if namespace == "" { // cluster-scoped resources don't have namespace
 		return true
 	}
 

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -5,52 +5,16 @@ package informer
 
 import (
 	"context"
-	"path/filepath"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/stolostron/search-collector/pkg/config"
-	"github.com/stolostron/search-v2-operator/api/v1alpha1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 )
-
-type namespaceCache struct {
-	mu        sync.RWMutex
-	allowed   map[string]bool
-	expiresAt time.Time
-	ttl       time.Duration
-}
-
-// get returns the cached namespace map, refreshing it if the TTL has expired.
-func (c *namespaceCache) get() map[string]bool {
-	c.mu.RLock()
-	if time.Now().Before(c.expiresAt) {
-		defer c.mu.RUnlock()
-		return c.allowed
-	}
-	c.mu.RUnlock()
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	// Double-check: another goroutine may have refreshed while we waited for the write lock.
-	if time.Now().Before(c.expiresAt) {
-		return c.allowed
-	}
-
-	c.allowed = resolveCollectNamespaces()
-	c.expiresAt = time.Now().Add(c.ttl)
-	return c.allowed
-}
-
-var nsCache = &namespaceCache{ttl: 2 * time.Minute}
 
 // GenericInformer ...
 type GenericInformer struct {
@@ -102,12 +66,10 @@ func (inform *GenericInformer) Run(ctx context.Context) {
 				inform.client = config.GetDynamicClient()
 			}
 
-			collectNamespaces := nsCache.get()
-
-			err := inform.listAndResync(collectNamespaces)
+			err := inform.listAndResync()
 			if err == nil {
 				inform.initialized.Store(true)
-				inform.watch(ctx.Done(), collectNamespaces)
+				inform.watch(ctx.Done())
 			}
 		}
 	}
@@ -125,135 +87,9 @@ func newUnstructured(kind, uid string) *unstructured.Unstructured {
 	}
 }
 
-func filterBySelectors(kubeClient kubernetes.Interface, nsSelector *v1alpha1.NamespaceSelector) (*v1.NamespaceList, error) {
-	// Build a label selector from matchLabels and matchExpressions
-	labelSelector := ""
-	if len(nsSelector.MatchLabels) > 0 || len(nsSelector.MatchExpressions) > 0 {
-		ls := &metav1.LabelSelector{
-			MatchLabels:      nsSelector.MatchLabels,
-			MatchExpressions: nsSelector.MatchExpressions,
-		}
-		selector, err := metav1.LabelSelectorAsSelector(ls)
-		if err != nil {
-			klog.Warningf("Error parsing namespace label selector: %v. Skipping label filtering.", err)
-		} else {
-			labelSelector = selector.String()
-		}
-	}
-
-	// List namespaces filtered by labels
-	nsList, err := kubeClient.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{
-		LabelSelector: labelSelector,
-	})
-	if err != nil {
-		klog.Warningf("Error listing namespaces: %v. Skipping namespace filtering.", err)
-		return nil, err
-	}
-
-	return nsList, nil
-}
-
-func filterByGlobs(nsList *v1.NamespaceList, nsSelector *v1alpha1.NamespaceSelector) map[string]bool {
-	result := make(map[string]bool, 0)
-	for _, ns := range nsList.Items {
-		name := ns.Name
-
-		// Include filter: if include list is specified, namespace must match at least one pattern
-		if len(nsSelector.Include) > 0 {
-			matched := false
-			for _, pattern := range nsSelector.Include {
-				ok, err := filepath.Match(pattern, name)
-				if err != nil {
-					klog.Warningf("Invalid include glob pattern %q: %v", pattern, err)
-					continue
-				}
-				if ok {
-					matched = true
-					break
-				}
-			}
-			if !matched {
-				continue
-			}
-		}
-
-		// Exclude filter: if namespace matches any exclude pattern, skip it
-		if len(nsSelector.Exclude) > 0 {
-			excluded := false
-			for _, pattern := range nsSelector.Exclude {
-				ok, err := filepath.Match(pattern, name)
-				if err != nil {
-					klog.Warningf("Invalid exclude glob pattern %q: %v", pattern, err)
-					continue
-				}
-				if ok {
-					excluded = true
-					break
-				}
-			}
-			if excluded {
-				continue
-			}
-		}
-
-		// Add namespace to map that met labels, expressions, includes, and excludes
-		result[name] = true
-	}
-	return result
-}
-
-// resolveCollectNamespaces fetches the CollectorConfig and resolves the namespaceSelector
-// to a flat map of allowed namespace names. Called by nsCache.get() when the TTL expires.
-func resolveCollectNamespaces() map[string]bool {
-	if !config.Cfg.FeatureConfigurableCollection {
-		return nil
-	}
-
-	unstructuredConfig, err := config.GetDynamicClient().Resource(schema.GroupVersionResource{
-		Group:    "search.open-cluster-management.io",
-		Version:  "v1alpha1",
-		Resource: "collectorconfigs",
-	}).Namespace(config.Cfg.PodNamespace).Get(context.Background(), "collector-config", metav1.GetOptions{})
-	if err != nil {
-		klog.Infof("Could not load collector-config resource: %v. Using default config only.", err)
-		return nil
-	}
-
-	var collectorConfig v1alpha1.CollectorConfig
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredConfig.Object, &collectorConfig); err != nil {
-		klog.Warningf("Could not convert collector-config to typed object: %v. Using default config only.", err)
-		return nil
-	}
-
-	// No collectNamespaces or namespaceSelector configured — collect everywhere
-	if collectorConfig.Spec.CollectNamespaces == nil || collectorConfig.Spec.CollectNamespaces.NamespaceSelector == nil {
-		return nil
-	}
-	nsSelector := collectorConfig.Spec.CollectNamespaces.NamespaceSelector
-
-	// Nothing specified — collect everywhere
-	if len(nsSelector.Include) == 0 && len(nsSelector.Exclude) == 0 &&
-		len(nsSelector.MatchLabels) == 0 && len(nsSelector.MatchExpressions) == 0 {
-		return nil
-	}
-
-	// List namespaces filtered by labelSelectors and matchExpressions
-	nsList, err := filterBySelectors(config.GetKubeClient(config.GetKubeConfig()), nsSelector)
-	if err != nil {
-		klog.Warningf("Error listing namespaces: %v. Skipping namespace filtering.", err)
-		return nil
-	}
-
-	// Filter namespaces by include and exclude namespace globs
-	result := filterByGlobs(nsList, nsSelector)
-
-	klog.V(3).Infof("Resolved collectNamespaces to %d namespaces: %v", len(result), result)
-	return result
-}
-
 // List current resources and fires ADDED events. Then sync the current state with the previous
 // state and delete any resources that are still in our cache, but no longer exist in the cluster.
-func (inform *GenericInformer) listAndResync(collectNamespaces map[string]bool) error {
+func (inform *GenericInformer) listAndResync() error {
 
 	// Keep track of new resources added to consolidate against the previous state.
 	newResourceIndex := make(map[string]string)
@@ -271,7 +107,7 @@ func (inform *GenericInformer) listAndResync(collectNamespaces map[string]bool) 
 
 		// Add all resources filtered by namespace
 		for i := range resources.Items {
-			if !isNamespaceAllowed(collectNamespaces, resources.Items[i].GetNamespace()) {
+			if !isNamespaceAllowed(resources.Items[i].GetNamespace()) {
 				continue
 			}
 
@@ -306,7 +142,7 @@ func (inform *GenericInformer) listAndResync(collectNamespaces map[string]bool) 
 }
 
 // Watch resources and process events.
-func (inform *GenericInformer) watch(stopper <-chan struct{}, collectNamespaces map[string]bool) {
+func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 	watch, watchError := inform.client.Resource(inform.gvr).Watch(context.TODO(), metav1.ListOptions{})
 	if watchError != nil {
 		klog.Warningf("Error watching resources for %s.  Error: %s", inform.gvr.String(), watchError)
@@ -338,12 +174,17 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}, collectNamespaces 
 					continue
 				}
 
-				if !isNamespaceAllowed(collectNamespaces, obj.GetNamespace()) {
+				if !isNamespaceAllowed(obj.GetNamespace()) {
 					continue
 				}
 
 				inform.AddFunc(obj)
 				inform.resourceIndex[string(obj.GetUID())] = obj.GetResourceVersion()
+
+				// Namespace changes affect which resources pass the namespace filter.
+				if inform.gvr.Resource == "namespaces" {
+					nsFilterCache.invalidate()
+				}
 
 			case "MODIFIED":
 				klog.V(5).Infof("Received MODIFY event. Kind: %s ", inform.gvr.Resource)
@@ -354,12 +195,17 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}, collectNamespaces 
 					continue
 				}
 
-				if !isNamespaceAllowed(collectNamespaces, obj.GetNamespace()) {
+				if !isNamespaceAllowed(obj.GetNamespace()) {
 					continue
 				}
 
 				inform.UpdateFunc(nil, obj)
 				inform.resourceIndex[string(obj.GetUID())] = obj.GetResourceVersion()
+
+				// Label changes on namespaces can affect label selector results.
+				if inform.gvr.Resource == "namespaces" {
+					nsFilterCache.invalidate()
+				}
 
 			case "DELETED":
 				klog.V(5).Infof("Received DELETED event. Kind: %s ", inform.gvr.Resource)
@@ -370,12 +216,17 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}, collectNamespaces 
 					continue
 				}
 
-				if !isNamespaceAllowed(collectNamespaces, obj.GetNamespace()) {
+				if !isNamespaceAllowed(obj.GetNamespace()) {
 					continue
 				}
 
 				inform.DeleteFunc(obj)
 				delete(inform.resourceIndex, string(obj.GetUID()))
+
+				// Namespace deletion affects the allowed namespace set.
+				if inform.gvr.Resource == "namespaces" {
+					nsFilterCache.invalidate()
+				}
 
 			case "ERROR":
 				klog.V(2).Infof("Received ERROR event. Ending listAndWatch() for %s event: %s", inform.gvr.String(), event)
@@ -400,21 +251,4 @@ func (inform *GenericInformer) WaitUntilInitialized(timeout time.Duration) {
 		}
 		time.Sleep(time.Duration(10) * time.Millisecond)
 	}
-}
-
-func isNamespaceAllowed(allowedNSMap map[string]bool, namespace string) bool {
-	if !config.Cfg.FeatureConfigurableCollection {
-		return true
-	}
-
-	if namespace == "" { // cluster-scoped resources don't have namespace
-		return true
-	}
-
-	if allowedNSMap == nil { // error in processing allowedNamespaceMap: collect everywhere
-		return true
-	}
-
-	_, ok := allowedNSMap[namespace]
-	return ok
 }

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -230,10 +230,6 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 				if !nsFilterCache.isNamespaceAllowed(obj.GetNamespace()) {
 					continue
 				}
-				// Namespace deletions affect which resources pass the namespace filter.
-				if inform.gvr.Resource == "namespaces" && inform.gvr.Group == "" {
-					nsFilterCache.regenerate()
-				}
 
 				inform.DeleteFunc(obj)
 				delete(inform.resourceIndex, string(obj.GetUID()))

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -107,8 +107,10 @@ func (inform *GenericInformer) listAndResync() error {
 
 		// Add all resources filtered by namespace
 		for i := range resources.Items {
-			if !isNamespaceAllowed(resources.Items[i].GetNamespace()) {
-				continue
+			if config.Cfg.FeatureConfigurableCollection {
+				if !nsFilterCache.isNamespaceAllowed(resources.Items[i].GetNamespace()) {
+					continue
+				}
 			}
 
 			klog.V(5).Infof("KIND: %s UUID: %s, ResourceVersion: %s",
@@ -174,17 +176,21 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 					continue
 				}
 
-				if !isNamespaceAllowed(obj.GetNamespace()) {
+				// FUTURE: Better handing on namespace additions
+				//   on startup and when we restart informers we will get a lot of namespaces being ADDED
+				//   results in lots of invalidation and computation of namespace filter cache
+				//   for example check if namespace is already in filter and skip invalidation on ADDED
+				//   https://github.com/stolostron/search-collector/pull/866#discussion_r3196919607
+				if !nsFilterCache.isNamespaceAllowed(obj.GetNamespace()) {
 					continue
+				}
+				// Namespace additions affect which resources pass the namespace filter.
+				if inform.gvr.Resource == "namespaces" && inform.gvr.Group == "" {
+					nsFilterCache.regenerate()
 				}
 
 				inform.AddFunc(obj)
 				inform.resourceIndex[string(obj.GetUID())] = obj.GetResourceVersion()
-
-				// Namespace changes affect which resources pass the namespace filter.
-				if inform.gvr.Resource == "namespaces" {
-					nsFilterCache.invalidate()
-				}
 
 			case "MODIFIED":
 				klog.V(5).Infof("Received MODIFY event. Kind: %s ", inform.gvr.Resource)
@@ -195,17 +201,19 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 					continue
 				}
 
-				if !isNamespaceAllowed(obj.GetNamespace()) {
+				// FUTURE: Better handling on namespace modifications
+				//   for example invalidate the namespace filter cache on CollectorConfig changes
+				//   https://github.com/stolostron/search-collector/pull/866#discussion_r3196850432
+				if !nsFilterCache.isNamespaceAllowed(obj.GetNamespace()) {
 					continue
+				}
+				// Namespace changes affect which resources pass the namespace filter.
+				if inform.gvr.Resource == "namespaces" && inform.gvr.Group == "" {
+					nsFilterCache.regenerate()
 				}
 
 				inform.UpdateFunc(nil, obj)
 				inform.resourceIndex[string(obj.GetUID())] = obj.GetResourceVersion()
-
-				// Label changes on namespaces can affect label selector results.
-				if inform.gvr.Resource == "namespaces" {
-					nsFilterCache.invalidate()
-				}
 
 			case "DELETED":
 				klog.V(5).Infof("Received DELETED event. Kind: %s ", inform.gvr.Resource)
@@ -216,17 +224,19 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 					continue
 				}
 
-				if !isNamespaceAllowed(obj.GetNamespace()) {
+				// FUTURE: better handling on namespace deletion
+				//   for example remove the namespace key from the map
+				//   https://github.com/stolostron/search-collector/pull/866#discussion_r3196773820
+				if !nsFilterCache.isNamespaceAllowed(obj.GetNamespace()) {
 					continue
+				}
+				// Namespace deletions affect which resources pass the namespace filter.
+				if inform.gvr.Resource == "namespaces" && inform.gvr.Group == "" {
+					nsFilterCache.regenerate()
 				}
 
 				inform.DeleteFunc(obj)
 				delete(inform.resourceIndex, string(obj.GetUID()))
-
-				// Namespace deletion affects the allowed namespace set.
-				if inform.gvr.Resource == "namespaces" {
-					nsFilterCache.invalidate()
-				}
 
 			case "ERROR":
 				klog.V(2).Infof("Received ERROR event. Ending listAndWatch() for %s event: %s", inform.gvr.String(), event)

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -107,10 +107,8 @@ func (inform *GenericInformer) listAndResync() error {
 
 		// Add all resources filtered by namespace
 		for i := range resources.Items {
-			if config.Cfg.FeatureConfigurableCollection {
-				if !nsFilterCache.isNamespaceAllowed(resources.Items[i].GetNamespace()) {
-					continue
-				}
+			if !nsFilterCache.isNamespaceAllowed(resources.Items[i].GetNamespace()) {
+				continue
 			}
 
 			klog.V(5).Infof("KIND: %s UUID: %s, ResourceVersion: %s",

--- a/pkg/informer/informer_test.go
+++ b/pkg/informer/informer_test.go
@@ -8,11 +8,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stolostron/search-v2-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
+	fakeClient "k8s.io/client-go/kubernetes/fake"
 )
 
 // Create a GroupVersionResource
@@ -96,7 +100,7 @@ func Test_listAndResync(t *testing.T) {
 	informer, addFuncCount, _, _ := initInformer()
 
 	// Execute function
-	err := informer.listAndResync()
+	err := informer.listAndResync(nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -117,7 +121,7 @@ func Test_listAndResync_syncWithPrevState(t *testing.T) {
 	informer.resourceIndex["id-001"] = "some-resource-version"   // This resource won't get deleted.
 
 	// Execute function
-	err := informer.listAndResync()
+	err := informer.listAndResync(nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -243,7 +247,7 @@ func Test_watch(t *testing.T) {
 
 	// Start the watch() and wait until it is stopped.
 	go func() {
-		informer.watch(stopper)
+		informer.watch(stopper, nil)
 		close(done)
 	}()
 	// Wait 5 ms and send the signal to stop the watch()
@@ -269,4 +273,259 @@ func Test_WaitUntilInitialized_timeout(t *testing.T) {
 	if time.Since(start) > time.Duration(15)*time.Millisecond {
 		t.Errorf("Expected WaitUntilInitialized to time out within 15 milliseconds, but got %s", time.Since(start))
 	}
+}
+
+func TestFilterByGlobsIncludeNoExclude(t *testing.T) {
+	// Given: a list of namespaces: [foo, bar], include: [foo], exclude: []
+	namespaceList := &corev1.NamespaceList{
+		Items: []corev1.Namespace{
+			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
+		},
+	}
+
+	namespaceSelector := &v1alpha1.NamespaceSelector{
+		Include: []string{"foo"},
+		Exclude: []string{},
+	}
+
+	// When: we filter on namespaceList
+	result := filterByGlobs(namespaceList, namespaceSelector)
+
+	// Then: foo remains
+	assert.Equal(t, len(result), 1)
+	assert.Equal(t, true, result["foo"])
+}
+
+func TestFilterByGlobsExcludeNoInclude(t *testing.T) {
+	// Given: a list of namespaces: [foo, bar], include: [], exclude: [foo]
+	namespaceList := &corev1.NamespaceList{
+		Items: []corev1.Namespace{
+			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
+		},
+	}
+
+	namespaceSelector := &v1alpha1.NamespaceSelector{
+		Include: []string{},
+		Exclude: []string{"foo"},
+	}
+
+	// When: we filter on namespaceList
+	result := filterByGlobs(namespaceList, namespaceSelector)
+
+	// Then: bar remains
+	assert.Equal(t, len(result), 1)
+	assert.Equal(t, true, result["bar"])
+}
+
+func TestFilterByGlobsIncludeMatchExclude(t *testing.T) {
+	// Given: a list of namespaces: [foo, bar], include: [foo], exclude: [foo]
+	namespaceList := &corev1.NamespaceList{
+		Items: []corev1.Namespace{
+			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
+		},
+	}
+
+	namespaceSelector := &v1alpha1.NamespaceSelector{
+		Include: []string{"foo"},
+		Exclude: []string{"foo"},
+	}
+
+	// When: we filter on namespaceList
+	result := filterByGlobs(namespaceList, namespaceSelector)
+
+	// Then: no namespaces to collect
+	assert.Equal(t, len(result), 0)
+}
+
+func TestFilterByGlobsIncludeExclude(t *testing.T) {
+	// Given: a list of namespaces: [foo, bar], include: [foo], exclude: [bar]
+	namespaceList := &corev1.NamespaceList{
+		Items: []corev1.Namespace{
+			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
+		},
+	}
+
+	namespaceSelector := &v1alpha1.NamespaceSelector{
+		Include: []string{"foo"},
+		Exclude: []string{"bar"},
+	}
+
+	// When: we filter on namespaceList
+	result := filterByGlobs(namespaceList, namespaceSelector)
+
+	// Then: foo remains
+	assert.Equal(t, len(result), 1)
+	assert.Equal(t, true, result["foo"])
+}
+
+func TestFilterByGlobsIncludeWildcardNoExclude(t *testing.T) {
+	// Given: a list of namespaces: [foo, bar, baz], include: [ba*], exclude: []
+	namespaceList := &corev1.NamespaceList{
+		Items: []corev1.Namespace{
+			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "baz"}},
+		},
+	}
+
+	namespaceSelector := &v1alpha1.NamespaceSelector{
+		Include: []string{"ba*"},
+		Exclude: []string{},
+	}
+
+	// When: we filter on namespaceList
+	result := filterByGlobs(namespaceList, namespaceSelector)
+
+	// Then: bar and baz remain
+	assert.Equal(t, len(result), 2)
+	assert.Equal(t, true, result["bar"])
+	assert.Equal(t, true, result["baz"])
+}
+
+func TestFilterByGlobsExcludeWildcardNoInclude(t *testing.T) {
+	// Given: a list of namespaces: [foo, bar, baz], include: [], exclude: [ba*]
+	namespaceList := &corev1.NamespaceList{
+		Items: []corev1.Namespace{
+			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "baz"}},
+		},
+	}
+
+	namespaceSelector := &v1alpha1.NamespaceSelector{
+		Include: []string{},
+		Exclude: []string{"ba*"},
+	}
+
+	// When: we filter on namespaceList
+	result := filterByGlobs(namespaceList, namespaceSelector)
+
+	// Then: foo
+	assert.Equal(t, len(result), 1)
+	assert.Equal(t, true, result["foo"])
+}
+
+func TestFilterBySelectorsMatchLabels(t *testing.T) {
+	// Given a list of namespaces: [prod-app, dev-app, no-labels], selector matching env=prod
+	fc := fakeClient.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app", Labels: map[string]string{"env": "prod"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app", Labels: map[string]string{"env": "dev"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "no-labels"}},
+	)
+
+	nsSelector := &v1alpha1.NamespaceSelector{
+		MatchLabels: map[string]string{"env": "prod"},
+	}
+
+	// When: we filter by label selectors
+	result, err := filterBySelectors(fc, nsSelector)
+
+	// Then: prod-app remains
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result.Items))
+	assert.Equal(t, "prod-app", result.Items[0].Name)
+}
+
+func TestFilterBySelectorsMatchExpressionsIn(t *testing.T) {
+	// Given a list of namespaces: [prod-app, dev-app, no-labels], selector matching env=prod
+	fc := fakeClient.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app", Labels: map[string]string{"env": "prod"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app", Labels: map[string]string{"env": "dev"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "no-labels"}},
+	)
+
+	nsSelector := &v1alpha1.NamespaceSelector{
+		MatchExpressions: []v1.LabelSelectorRequirement{
+			{Key: "env", Values: []string{"prod"}, Operator: v1.LabelSelectorOpIn},
+		},
+	}
+
+	// When: we filter by expression selectors
+	result, err := filterBySelectors(fc, nsSelector)
+
+	// Then: prod-app remains
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result.Items))
+	assert.Equal(t, "prod-app", result.Items[0].Name)
+}
+
+func TestFilterBySelectorsMatchExpressionsNotIn(t *testing.T) {
+	// Given a list of namespaces: [prod-app, dev-app, no-labels], selector matching env!=prod
+	fc := fakeClient.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app", Labels: map[string]string{"env": "prod"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app", Labels: map[string]string{"env": "dev"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "no-labels"}},
+	)
+
+	nsSelector := &v1alpha1.NamespaceSelector{
+		MatchExpressions: []v1.LabelSelectorRequirement{
+			{Key: "env", Values: []string{"prod"}, Operator: v1.LabelSelectorOpNotIn},
+		},
+	}
+
+	// When: we filter by expression selectors
+	result, err := filterBySelectors(fc, nsSelector)
+
+	// Then: dev-app and no-labels remains
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(result.Items))
+	assert.Equal(t, "dev-app", result.Items[0].Name)
+	assert.Equal(t, "no-labels", result.Items[1].Name)
+}
+
+func TestFilterBySelectorsMatchExpressionsNotInWithLabels(t *testing.T) {
+	// Given a list of namespaces: [prod-app, dev-app, no-labels], selector matching env!=prod and label env=dev
+	fc := fakeClient.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app", Labels: map[string]string{"env": "prod"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app", Labels: map[string]string{"env": "dev"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "no-labels"}},
+	)
+
+	nsSelector := &v1alpha1.NamespaceSelector{
+		MatchExpressions: []v1.LabelSelectorRequirement{
+			{Key: "env", Values: []string{"prod"}, Operator: v1.LabelSelectorOpNotIn},
+		},
+		MatchLabels: map[string]string{"env": "dev"},
+	}
+
+	// When: we filter by expression selectors
+	result, err := filterBySelectors(fc, nsSelector)
+
+	// Then: dev-app remains
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result.Items))
+	assert.Equal(t, "dev-app", result.Items[0].Name)
+}
+
+func TestFilterBySelectorsThenGlobs(t *testing.T) {
+	// Given a list of namespaces: [prod-app, dev-app, dev-app-2, no-labels], selector matching env!=prod and label env=dev and glob Include:[dev-*]
+	fc := fakeClient.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app", Labels: map[string]string{"env": "prod"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app", Labels: map[string]string{"env": "dev"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app-2", Labels: map[string]string{"env": "dev"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "no-labels"}},
+	)
+
+	nsSelector := &v1alpha1.NamespaceSelector{
+		MatchExpressions: []v1.LabelSelectorRequirement{
+			{Key: "env", Values: []string{"prod"}, Operator: v1.LabelSelectorOpNotIn},
+		},
+		MatchLabels: map[string]string{"env": "dev"},
+		Include:     []string{"dev-*"},
+		Exclude:     []string{},
+	}
+
+	// When: we filter by expression selectors and glob
+	interim, err := filterBySelectors(fc, nsSelector)
+	result := filterByGlobs(interim, nsSelector)
+
+	// Then: dev-app and dev-app-2 remain
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(result))
+	assert.Equal(t, true, result["dev-app"])
+	assert.Equal(t, true, result["dev-app-2"])
 }

--- a/pkg/informer/informer_test.go
+++ b/pkg/informer/informer_test.go
@@ -293,7 +293,7 @@ func TestFilterByGlobsIncludeNoExclude(t *testing.T) {
 	result := filterByGlobs(namespaceList, namespaceSelector)
 
 	// Then: foo remains
-	assert.Equal(t, len(result), 1)
+	assert.Equal(t, 1, len(result))
 	assert.Equal(t, true, result["foo"])
 }
 
@@ -315,7 +315,7 @@ func TestFilterByGlobsExcludeNoInclude(t *testing.T) {
 	result := filterByGlobs(namespaceList, namespaceSelector)
 
 	// Then: bar remains
-	assert.Equal(t, len(result), 1)
+	assert.Equal(t, 1, len(result))
 	assert.Equal(t, true, result["bar"])
 }
 
@@ -337,7 +337,7 @@ func TestFilterByGlobsIncludeMatchExclude(t *testing.T) {
 	result := filterByGlobs(namespaceList, namespaceSelector)
 
 	// Then: no namespaces to collect
-	assert.Equal(t, len(result), 0)
+	assert.Equal(t, 0, len(result))
 }
 
 func TestFilterByGlobsIncludeExclude(t *testing.T) {
@@ -358,7 +358,7 @@ func TestFilterByGlobsIncludeExclude(t *testing.T) {
 	result := filterByGlobs(namespaceList, namespaceSelector)
 
 	// Then: foo remains
-	assert.Equal(t, len(result), 1)
+	assert.Equal(t, 1, len(result))
 	assert.Equal(t, true, result["foo"])
 }
 
@@ -381,7 +381,7 @@ func TestFilterByGlobsIncludeWildcardNoExclude(t *testing.T) {
 	result := filterByGlobs(namespaceList, namespaceSelector)
 
 	// Then: bar and baz remain
-	assert.Equal(t, len(result), 2)
+	assert.Equal(t, 2, len(result))
 	assert.Equal(t, true, result["bar"])
 	assert.Equal(t, true, result["baz"])
 }
@@ -405,7 +405,7 @@ func TestFilterByGlobsExcludeWildcardNoInclude(t *testing.T) {
 	result := filterByGlobs(namespaceList, namespaceSelector)
 
 	// Then: foo
-	assert.Equal(t, len(result), 1)
+	assert.Equal(t, 1, len(result))
 	assert.Equal(t, true, result["foo"])
 }
 
@@ -528,4 +528,25 @@ func TestFilterBySelectorsThenGlobs(t *testing.T) {
 	assert.Equal(t, 2, len(result))
 	assert.Equal(t, true, result["dev-app"])
 	assert.Equal(t, true, result["dev-app-2"])
+}
+
+func TestFilterByEmptySelectors(t *testing.T) {
+	// Given: a list of namespaces: [foo, bar, baz] with no filters
+	namespaceList := &corev1.NamespaceList{
+		Items: []corev1.Namespace{
+			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "baz"}},
+		},
+	}
+	namespaceSelector := &v1alpha1.NamespaceSelector{}
+
+	// When: we filter on namespaceList
+	result := filterByGlobs(namespaceList, namespaceSelector)
+
+	// Then: foo, bar, and baz remain
+	assert.Equal(t, 3, len(result))
+	assert.Equal(t, true, result["foo"])
+	assert.Equal(t, true, result["bar"])
+	assert.Equal(t, true, result["baz"])
 }

--- a/pkg/informer/informer_test.go
+++ b/pkg/informer/informer_test.go
@@ -5,19 +5,14 @@ package informer
 
 import (
 	"context"
-	"github.com/stolostron/search-collector/pkg/config"
 	"testing"
 	"time"
 
-	"github.com/stolostron/search-v2-operator/api/v1alpha1"
-	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
-	fakeClient "k8s.io/client-go/kubernetes/fake"
 )
 
 // Create a GroupVersionResource
@@ -101,7 +96,7 @@ func Test_listAndResync(t *testing.T) {
 	informer, addFuncCount, _, _ := initInformer()
 
 	// Execute function
-	err := informer.listAndResync(nil)
+	err := informer.listAndResync()
 	if err != nil {
 		t.Error(err)
 	}
@@ -122,7 +117,7 @@ func Test_listAndResync_syncWithPrevState(t *testing.T) {
 	informer.resourceIndex["id-001"] = "some-resource-version"   // This resource won't get deleted.
 
 	// Execute function
-	err := informer.listAndResync(nil)
+	err := informer.listAndResync()
 	if err != nil {
 		t.Error(err)
 	}
@@ -248,7 +243,7 @@ func Test_watch(t *testing.T) {
 
 	// Start the watch() and wait until it is stopped.
 	go func() {
-		informer.watch(stopper, nil)
+		informer.watch(stopper)
 		close(done)
 	}()
 	// Wait 5 ms and send the signal to stop the watch()
@@ -274,341 +269,4 @@ func Test_WaitUntilInitialized_timeout(t *testing.T) {
 	if time.Since(start) > time.Duration(15)*time.Millisecond {
 		t.Errorf("Expected WaitUntilInitialized to time out within 15 milliseconds, but got %s", time.Since(start))
 	}
-}
-
-func TestFilterByGlobsIncludeNoExclude(t *testing.T) {
-	// Given: a list of namespaces: [foo, bar], include: [foo], exclude: []
-	namespaceList := &corev1.NamespaceList{
-		Items: []corev1.Namespace{
-			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
-			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
-		},
-	}
-
-	namespaceSelector := &v1alpha1.NamespaceSelector{
-		Include: []string{"foo"},
-		Exclude: []string{},
-	}
-
-	// When: we filter on namespaceList
-	result := filterByGlobs(namespaceList, namespaceSelector)
-
-	// Then: foo remains
-	assert.Equal(t, 1, len(result))
-	assert.Equal(t, true, result["foo"])
-}
-
-func TestFilterByGlobsExcludeNoInclude(t *testing.T) {
-	// Given: a list of namespaces: [foo, bar], include: [], exclude: [foo]
-	namespaceList := &corev1.NamespaceList{
-		Items: []corev1.Namespace{
-			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
-			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
-		},
-	}
-
-	namespaceSelector := &v1alpha1.NamespaceSelector{
-		Include: []string{},
-		Exclude: []string{"foo"},
-	}
-
-	// When: we filter on namespaceList
-	result := filterByGlobs(namespaceList, namespaceSelector)
-
-	// Then: bar remains
-	assert.Equal(t, 1, len(result))
-	assert.Equal(t, true, result["bar"])
-}
-
-func TestFilterByGlobsIncludeMatchExclude(t *testing.T) {
-	// Given: a list of namespaces: [foo, bar], include: [foo], exclude: [foo]
-	namespaceList := &corev1.NamespaceList{
-		Items: []corev1.Namespace{
-			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
-			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
-		},
-	}
-
-	namespaceSelector := &v1alpha1.NamespaceSelector{
-		Include: []string{"foo"},
-		Exclude: []string{"foo"},
-	}
-
-	// When: we filter on namespaceList
-	result := filterByGlobs(namespaceList, namespaceSelector)
-
-	// Then: no namespaces to collect
-	assert.Equal(t, 0, len(result))
-}
-
-func TestFilterByGlobsIncludeExclude(t *testing.T) {
-	// Given: a list of namespaces: [foo, bar], include: [foo], exclude: [bar]
-	namespaceList := &corev1.NamespaceList{
-		Items: []corev1.Namespace{
-			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
-			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
-		},
-	}
-
-	namespaceSelector := &v1alpha1.NamespaceSelector{
-		Include: []string{"foo"},
-		Exclude: []string{"bar"},
-	}
-
-	// When: we filter on namespaceList
-	result := filterByGlobs(namespaceList, namespaceSelector)
-
-	// Then: foo remains
-	assert.Equal(t, 1, len(result))
-	assert.Equal(t, true, result["foo"])
-}
-
-func TestFilterByGlobsIncludeWildcardNoExclude(t *testing.T) {
-	// Given: a list of namespaces: [foo, bar, baz], include: [ba*], exclude: []
-	namespaceList := &corev1.NamespaceList{
-		Items: []corev1.Namespace{
-			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
-			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
-			{ObjectMeta: v1.ObjectMeta{Name: "baz"}},
-		},
-	}
-
-	namespaceSelector := &v1alpha1.NamespaceSelector{
-		Include: []string{"ba*"},
-		Exclude: []string{},
-	}
-
-	// When: we filter on namespaceList
-	result := filterByGlobs(namespaceList, namespaceSelector)
-
-	// Then: bar and baz remain
-	assert.Equal(t, 2, len(result))
-	assert.Equal(t, true, result["bar"])
-	assert.Equal(t, true, result["baz"])
-}
-
-func TestFilterByGlobsExcludeWildcardNoInclude(t *testing.T) {
-	// Given: a list of namespaces: [foo, bar, baz], include: [], exclude: [ba*]
-	namespaceList := &corev1.NamespaceList{
-		Items: []corev1.Namespace{
-			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
-			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
-			{ObjectMeta: v1.ObjectMeta{Name: "baz"}},
-		},
-	}
-
-	namespaceSelector := &v1alpha1.NamespaceSelector{
-		Include: []string{},
-		Exclude: []string{"ba*"},
-	}
-
-	// When: we filter on namespaceList
-	result := filterByGlobs(namespaceList, namespaceSelector)
-
-	// Then: foo
-	assert.Equal(t, 1, len(result))
-	assert.Equal(t, true, result["foo"])
-}
-
-func TestFilterBySelectorsMatchLabels(t *testing.T) {
-	// Given a list of namespaces: [prod-app, dev-app, no-labels], selector matching env=prod
-	fc := fakeClient.NewSimpleClientset(
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app", Labels: map[string]string{"env": "prod"}}},
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app", Labels: map[string]string{"env": "dev"}}},
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "no-labels"}},
-	)
-
-	nsSelector := &v1alpha1.NamespaceSelector{
-		MatchLabels: map[string]string{"env": "prod"},
-	}
-
-	// When: we filter by label selectors
-	result, err := filterBySelectors(fc, nsSelector)
-
-	// Then: prod-app remains
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(result.Items))
-	assert.Equal(t, "prod-app", result.Items[0].Name)
-}
-
-func TestFilterBySelectorsMatchExpressionsIn(t *testing.T) {
-	// Given a list of namespaces: [prod-app, dev-app, no-labels], selector matching env=prod
-	fc := fakeClient.NewSimpleClientset(
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app", Labels: map[string]string{"env": "prod"}}},
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app", Labels: map[string]string{"env": "dev"}}},
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "no-labels"}},
-	)
-
-	nsSelector := &v1alpha1.NamespaceSelector{
-		MatchExpressions: []v1.LabelSelectorRequirement{
-			{Key: "env", Values: []string{"prod"}, Operator: v1.LabelSelectorOpIn},
-		},
-	}
-
-	// When: we filter by expression selectors
-	result, err := filterBySelectors(fc, nsSelector)
-
-	// Then: prod-app remains
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(result.Items))
-	assert.Equal(t, "prod-app", result.Items[0].Name)
-}
-
-func TestFilterBySelectorsMatchExpressionsNotIn(t *testing.T) {
-	// Given a list of namespaces: [prod-app, dev-app, no-labels], selector matching env!=prod
-	fc := fakeClient.NewSimpleClientset(
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app", Labels: map[string]string{"env": "prod"}}},
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app", Labels: map[string]string{"env": "dev"}}},
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "no-labels"}},
-	)
-
-	nsSelector := &v1alpha1.NamespaceSelector{
-		MatchExpressions: []v1.LabelSelectorRequirement{
-			{Key: "env", Values: []string{"prod"}, Operator: v1.LabelSelectorOpNotIn},
-		},
-	}
-
-	// When: we filter by expression selectors
-	result, err := filterBySelectors(fc, nsSelector)
-
-	// Then: dev-app and no-labels remains
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(result.Items))
-	assert.Equal(t, "dev-app", result.Items[0].Name)
-	assert.Equal(t, "no-labels", result.Items[1].Name)
-}
-
-func TestFilterBySelectorsMatchExpressionsNotInWithLabels(t *testing.T) {
-	// Given a list of namespaces: [prod-app, dev-app, no-labels], selector matching env!=prod and label env=dev
-	fc := fakeClient.NewSimpleClientset(
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app", Labels: map[string]string{"env": "prod"}}},
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app", Labels: map[string]string{"env": "dev"}}},
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "no-labels"}},
-	)
-
-	nsSelector := &v1alpha1.NamespaceSelector{
-		MatchExpressions: []v1.LabelSelectorRequirement{
-			{Key: "env", Values: []string{"prod"}, Operator: v1.LabelSelectorOpNotIn},
-		},
-		MatchLabels: map[string]string{"env": "dev"},
-	}
-
-	// When: we filter by expression selectors
-	result, err := filterBySelectors(fc, nsSelector)
-
-	// Then: dev-app remains
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(result.Items))
-	assert.Equal(t, "dev-app", result.Items[0].Name)
-}
-
-func TestFilterBySelectorsThenGlobs(t *testing.T) {
-	// Given a list of namespaces: [prod-app, dev-app, dev-app-2, no-labels], selector matching env!=prod and label env=dev and glob Include:[dev-*]
-	fc := fakeClient.NewSimpleClientset(
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app", Labels: map[string]string{"env": "prod"}}},
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app", Labels: map[string]string{"env": "dev"}}},
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app-2", Labels: map[string]string{"env": "dev"}}},
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "no-labels"}},
-	)
-
-	nsSelector := &v1alpha1.NamespaceSelector{
-		MatchExpressions: []v1.LabelSelectorRequirement{
-			{Key: "env", Values: []string{"prod"}, Operator: v1.LabelSelectorOpNotIn},
-		},
-		MatchLabels: map[string]string{"env": "dev"},
-		Include:     []string{"dev-*"},
-		Exclude:     []string{},
-	}
-
-	// When: we filter by expression selectors and glob
-	interim, err := filterBySelectors(fc, nsSelector)
-	result := filterByGlobs(interim, nsSelector)
-
-	// Then: dev-app and dev-app-2 remain
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(result))
-	assert.Equal(t, true, result["dev-app"])
-	assert.Equal(t, true, result["dev-app-2"])
-}
-
-func TestFilterByEmptySelectors(t *testing.T) {
-	// Given: a list of namespaces: [foo, bar, baz] with no filters
-	fc := fakeClient.NewSimpleClientset(
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "baz"}},
-	)
-	namespaceSelector := &v1alpha1.NamespaceSelector{}
-
-	// When: we filter on namespaceList
-	interim, err := filterBySelectors(fc, namespaceSelector)
-	result := filterByGlobs(interim, namespaceSelector)
-
-	// Then: foo, bar, and baz remain
-	assert.NoError(t, err)
-	assert.Equal(t, 3, len(result))
-	assert.Equal(t, true, result["foo"])
-	assert.Equal(t, true, result["bar"])
-	assert.Equal(t, true, result["baz"])
-}
-
-// Feature flag disabled: allow everything regardless of map contents.
-func TestIsNamespaceAllowed_FeatureDisabled(t *testing.T) {
-	original := config.Cfg.FeatureConfigurableCollection
-	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
-	config.Cfg.FeatureConfigurableCollection = false
-
-	assert.True(t, isNamespaceAllowed(nil, "any-ns"))
-	assert.True(t, isNamespaceAllowed(map[string]bool{}, "any-ns"))
-	assert.True(t, isNamespaceAllowed(map[string]bool{"other": true}, "any-ns"))
-}
-
-// Nil map means no filter was configured: allow all namespaces.
-func TestIsNamespaceAllowed_NilMap(t *testing.T) {
-	original := config.Cfg.FeatureConfigurableCollection
-	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
-	config.Cfg.FeatureConfigurableCollection = true
-
-	assert.True(t, isNamespaceAllowed(nil, "any-ns"))
-}
-
-// Empty map means selector matched zero namespaces: block everything.
-func TestIsNamespaceAllowed_EmptyMap(t *testing.T) {
-	original := config.Cfg.FeatureConfigurableCollection
-	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
-	config.Cfg.FeatureConfigurableCollection = true
-
-	assert.False(t, isNamespaceAllowed(map[string]bool{}, "any-ns"))
-}
-
-// Cluster-scoped resources (empty namespace) always pass.
-func TestIsNamespaceAllowed_ClusterScoped(t *testing.T) {
-	original := config.Cfg.FeatureConfigurableCollection
-	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
-	config.Cfg.FeatureConfigurableCollection = true
-
-	assert.True(t, isNamespaceAllowed(map[string]bool{"ns1": true}, ""))
-	assert.True(t, isNamespaceAllowed(map[string]bool{}, ""))
-}
-
-// Namespace in the allowed map passes.
-func TestIsNamespaceAllowed_Allowed(t *testing.T) {
-	original := config.Cfg.FeatureConfigurableCollection
-	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
-	config.Cfg.FeatureConfigurableCollection = true
-
-	allowed := map[string]bool{"ns1": true, "ns2": true}
-	assert.True(t, isNamespaceAllowed(allowed, "ns1"))
-	assert.True(t, isNamespaceAllowed(allowed, "ns2"))
-}
-
-// Namespace not in the allowed map is blocked.
-func TestIsNamespaceAllowed_NotAllowed(t *testing.T) {
-	original := config.Cfg.FeatureConfigurableCollection
-	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
-	config.Cfg.FeatureConfigurableCollection = true
-
-	allowed := map[string]bool{"ns1": true}
-	assert.False(t, isNamespaceAllowed(allowed, "ns2"))
-	assert.False(t, isNamespaceAllowed(allowed, "kube-system"))
 }

--- a/pkg/informer/informer_test.go
+++ b/pkg/informer/informer_test.go
@@ -5,6 +5,7 @@ package informer
 
 import (
 	"context"
+	"github.com/stolostron/search-collector/pkg/config"
 	"testing"
 	"time"
 
@@ -532,21 +533,82 @@ func TestFilterBySelectorsThenGlobs(t *testing.T) {
 
 func TestFilterByEmptySelectors(t *testing.T) {
 	// Given: a list of namespaces: [foo, bar, baz] with no filters
-	namespaceList := &corev1.NamespaceList{
-		Items: []corev1.Namespace{
-			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
-			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
-			{ObjectMeta: v1.ObjectMeta{Name: "baz"}},
-		},
-	}
+	fc := fakeClient.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "baz"}},
+	)
 	namespaceSelector := &v1alpha1.NamespaceSelector{}
 
 	// When: we filter on namespaceList
-	result := filterByGlobs(namespaceList, namespaceSelector)
+	interim, err := filterBySelectors(fc, namespaceSelector)
+	result := filterByGlobs(interim, namespaceSelector)
 
 	// Then: foo, bar, and baz remain
+	assert.NoError(t, err)
 	assert.Equal(t, 3, len(result))
 	assert.Equal(t, true, result["foo"])
 	assert.Equal(t, true, result["bar"])
 	assert.Equal(t, true, result["baz"])
+}
+
+// Feature flag disabled: allow everything regardless of map contents.
+func TestIsNamespaceAllowed_FeatureDisabled(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = false
+
+	assert.True(t, isNamespaceAllowed(nil, "any-ns"))
+	assert.True(t, isNamespaceAllowed(map[string]bool{}, "any-ns"))
+	assert.True(t, isNamespaceAllowed(map[string]bool{"other": true}, "any-ns"))
+}
+
+// Nil map means no filter was configured: allow all namespaces.
+func TestIsNamespaceAllowed_NilMap(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = true
+
+	assert.True(t, isNamespaceAllowed(nil, "any-ns"))
+}
+
+// Empty map means selector matched zero namespaces: block everything.
+func TestIsNamespaceAllowed_EmptyMap(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = true
+
+	assert.False(t, isNamespaceAllowed(map[string]bool{}, "any-ns"))
+}
+
+// Cluster-scoped resources (empty namespace) always pass.
+func TestIsNamespaceAllowed_ClusterScoped(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = true
+
+	assert.True(t, isNamespaceAllowed(map[string]bool{"ns1": true}, ""))
+	assert.True(t, isNamespaceAllowed(map[string]bool{}, ""))
+}
+
+// Namespace in the allowed map passes.
+func TestIsNamespaceAllowed_Allowed(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = true
+
+	allowed := map[string]bool{"ns1": true, "ns2": true}
+	assert.True(t, isNamespaceAllowed(allowed, "ns1"))
+	assert.True(t, isNamespaceAllowed(allowed, "ns2"))
+}
+
+// Namespace not in the allowed map is blocked.
+func TestIsNamespaceAllowed_NotAllowed(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = true
+
+	allowed := map[string]bool{"ns1": true}
+	assert.False(t, isNamespaceAllowed(allowed, "ns2"))
+	assert.False(t, isNamespaceAllowed(allowed, "kube-system"))
 }

--- a/pkg/informer/namespaceFilter.go
+++ b/pkg/informer/namespaceFilter.go
@@ -1,0 +1,206 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package informer
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/stolostron/search-collector/pkg/config"
+	"github.com/stolostron/search-v2-operator/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+// namespaceFilterCache caches the resolved namespace map with a TTL so that
+// informers don't each have to fetch and resolve the CollectorConfig.
+type namespaceFilterCache struct {
+	mu        sync.RWMutex
+	allowed   map[string]bool
+	expiresAt time.Time
+}
+
+// get returns the cached namespace map, refreshing it if it has expired.
+func (c *namespaceFilterCache) get() map[string]bool {
+	c.mu.RLock()
+	if time.Now().Before(c.expiresAt) {
+		defer c.mu.RUnlock()
+		return c.allowed
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Double-check: another goroutine may have refreshed while we waited for the write lock.
+	if time.Now().Before(c.expiresAt) {
+		return c.allowed
+	}
+
+	c.allowed = resolveCollectNamespaces()
+	c.expiresAt = time.Now().Add(time.Duration(config.Cfg.NSFilterCacheTTLMS) * time.Millisecond)
+	return c.allowed
+}
+
+// invalidate forces the next get() call to refresh the cache.
+func (c *namespaceFilterCache) invalidate() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.expiresAt = time.Time{} // zero time is always before now
+}
+
+var nsFilterCache = &namespaceFilterCache{}
+
+// isNamespaceAllowed checks whether a resource in the given namespace should be collected.
+func isNamespaceAllowed(namespace string) bool {
+	if !config.Cfg.FeatureConfigurableCollection {
+		return true
+	}
+
+	if namespace == "" { // cluster-scoped resources don't have namespace
+		return true
+	}
+
+	allowedNSMap := nsFilterCache.get()
+	if allowedNSMap == nil { // error in processing allowedNamespaceMap: collect everywhere
+		return true
+	}
+
+	_, ok := allowedNSMap[namespace]
+	return ok
+}
+
+// filterBySelectors lists namespaces filtered by matchLabels and matchExpressions.
+func filterBySelectors(kubeClient kubernetes.Interface, nsSelector *v1alpha1.NamespaceSelector) (*v1.NamespaceList, error) {
+	// Build a label selector from matchLabels and matchExpressions
+	labelSelector := ""
+	if len(nsSelector.MatchLabels) > 0 || len(nsSelector.MatchExpressions) > 0 {
+		ls := &metav1.LabelSelector{
+			MatchLabels:      nsSelector.MatchLabels,
+			MatchExpressions: nsSelector.MatchExpressions,
+		}
+		selector, err := metav1.LabelSelectorAsSelector(ls)
+		if err != nil {
+			klog.Warningf("Error parsing namespace label selector: %v. Skipping label filtering.", err)
+		} else {
+			labelSelector = selector.String()
+		}
+	}
+
+	// List namespaces filtered by labels
+	nsList, err := kubeClient.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		klog.Warningf("Error listing namespaces: %v. Skipping namespace filtering.", err)
+		return nil, err
+	}
+
+	return nsList, nil
+}
+
+// filterByGlobs applies include/exclude filepath glob patterns to narrow a namespace list.
+func filterByGlobs(nsList *v1.NamespaceList, nsSelector *v1alpha1.NamespaceSelector) map[string]bool {
+	result := make(map[string]bool, 0)
+	for _, ns := range nsList.Items {
+		name := ns.Name
+
+		// Include filter: if include list is specified, namespace must match at least one pattern
+		if len(nsSelector.Include) > 0 {
+			matched := false
+			for _, pattern := range nsSelector.Include {
+				ok, err := filepath.Match(pattern, name)
+				if err != nil {
+					klog.Warningf("Invalid include glob pattern %q: %v", pattern, err)
+					continue
+				}
+				if ok {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+
+		// Exclude filter: if namespace matches any exclude pattern, skip it
+		if len(nsSelector.Exclude) > 0 {
+			excluded := false
+			for _, pattern := range nsSelector.Exclude {
+				ok, err := filepath.Match(pattern, name)
+				if err != nil {
+					klog.Warningf("Invalid exclude glob pattern %q: %v", pattern, err)
+					continue
+				}
+				if ok {
+					excluded = true
+					break
+				}
+			}
+			if excluded {
+				continue
+			}
+		}
+
+		// Add namespace to map that met labels, expressions, includes, and excludes
+		result[name] = true
+	}
+	return result
+}
+
+// resolveCollectNamespaces fetches the CollectorConfig and resolves the namespaceSelector
+// to a flat map of allowed namespace names. Called by nsCache.get() when the cache has expired.
+func resolveCollectNamespaces() map[string]bool {
+	if !config.Cfg.FeatureConfigurableCollection {
+		return nil
+	}
+
+	unstructuredConfig, err := config.GetDynamicClient().Resource(schema.GroupVersionResource{
+		Group:    "search.open-cluster-management.io",
+		Version:  "v1alpha1",
+		Resource: "collectorconfigs",
+	}).Namespace(config.Cfg.PodNamespace).Get(context.Background(), "collector-config", metav1.GetOptions{})
+	if err != nil {
+		klog.Infof("Could not load collector-config resource: %v. Will collect data from all namespaces.", err)
+		return nil
+	}
+
+	var collectorConfig v1alpha1.CollectorConfig
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredConfig.Object, &collectorConfig); err != nil {
+		klog.Warningf("Could not convert collector-config to typed object: %v. Will collect data from all namespaces.", err)
+		return nil
+	}
+
+	// No collectNamespaces or namespaceSelector configured — collect everywhere
+	if collectorConfig.Spec.CollectNamespaces == nil || collectorConfig.Spec.CollectNamespaces.NamespaceSelector == nil {
+		klog.V(2).Info("No collectNamespaces or namespaceSelector fields on collector-config. Will collect data from all namespaces.")
+		return nil
+	}
+	nsSelector := collectorConfig.Spec.CollectNamespaces.NamespaceSelector
+
+	// Nothing specified — collect everywhere
+	if len(nsSelector.Include) == 0 && len(nsSelector.Exclude) == 0 &&
+		len(nsSelector.MatchLabels) == 0 && len(nsSelector.MatchExpressions) == 0 {
+		klog.V(2).Info("No include, exclude, matchLabel, or matchExpression on collector-config. Will collect data from all namespaces.")
+		return nil
+	}
+
+	// List namespaces filtered by labelSelectors and matchExpressions
+	nsList, err := filterBySelectors(config.GetKubeClient(config.GetKubeConfig()), nsSelector)
+	if err != nil {
+		klog.Warningf("Error listing namespaces by matchLabel or matchExpression: %v. Skipping namespace filtering.", err)
+		return nil
+	}
+
+	// Filter namespaces by include and exclude namespace globs
+	result := filterByGlobs(nsList, nsSelector)
+
+	klog.V(3).Infof("Resolved collectNamespaces to %d namespaces: %v", len(result), result)
+	return result
+}

--- a/pkg/informer/namespaceFilter.go
+++ b/pkg/informer/namespaceFilter.go
@@ -108,6 +108,8 @@ func filterBySelectors(kubeClient kubernetes.Interface, nsSelector *v1alpha1.Nam
 }
 
 // filterByGlobs applies include/exclude filepath glob patterns to narrow a namespace list.
+// This should remain consistent with the GRC implementation.
+// https://github.com/stolostron/config-policy-controller/blob/main/pkg/common/pattern_util.go#L21-L64
 func filterByGlobs(nsList *v1.NamespaceList, nsSelector *v1alpha1.NamespaceSelector) map[string]bool {
 	result := make(map[string]bool, 0)
 	for _, ns := range nsList.Items {
@@ -159,10 +161,11 @@ func filterByGlobs(nsList *v1.NamespaceList, nsSelector *v1alpha1.NamespaceSelec
 
 // resolveCollectNamespaces fetches the CollectorConfig and resolves the namespaceSelector
 // to a flat map of allowed namespace names. Called by nsFilterCache.get() when the cache has expired.
-// three-step process:
-// 1. build a selector that ANDs matchLabels and matchExpressions, returning set of all namespaces that match
-// 2. check if include list namespaces are in the list, and if so,
-// 3. check if they should then be removed via the excludes list
+// This logic matches the GRC namespace selector.
+// Three-step process:
+//  1. build a selector that ANDs matchLabels and matchExpressions, returning set of all namespaces that match
+//  2. check if include list namespaces are in the list, and if so,
+//  3. check if they should then be removed via the excludes list
 func resolveCollectNamespaces() map[string]bool {
 	if !config.Cfg.FeatureConfigurableCollection {
 		return nil
@@ -174,19 +177,19 @@ func resolveCollectNamespaces() map[string]bool {
 		Resource: "collectorconfigs",
 	}).Namespace(config.Cfg.PodNamespace).Get(context.Background(), "collector-config", metav1.GetOptions{})
 	if err != nil {
-		klog.Infof("Could not load collector-config resource: %v. Will collect data from all namespaces.", err)
+		klog.Infof("Could not load CollectorConfig resource. Will collect data from all namespaces. Error: %v", err)
 		return nil
 	}
 
 	var collectorConfig v1alpha1.CollectorConfig
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredConfig.Object, &collectorConfig); err != nil {
-		klog.Warningf("Could not convert collector-config to typed object: %v. Will collect data from all namespaces.", err)
+		klog.Warningf("Could not convert CollectorConfig to typed object. Will collect data from all namespaces. Error: %v", err)
 		return nil
 	}
 
 	// No collectNamespaces or namespaceSelector configured — collect everywhere
 	if collectorConfig.Spec.CollectNamespaces == nil || collectorConfig.Spec.CollectNamespaces.NamespaceSelector == nil {
-		klog.V(2).Info("No collectNamespaces or namespaceSelector fields on collector-config. Will collect data from all namespaces.")
+		klog.V(2).Info("No collectNamespaces or namespaceSelector fields on CollectorConfig. Will collect data from all namespaces.")
 		return nil
 	}
 	nsSelector := collectorConfig.Spec.CollectNamespaces.NamespaceSelector
@@ -201,7 +204,7 @@ func resolveCollectNamespaces() map[string]bool {
 	// List namespaces filtered by labelSelectors and matchExpressions
 	nsList, err := filterBySelectors(config.GetKubeClient(config.GetKubeConfig()), nsSelector)
 	if err != nil {
-		klog.Warningf("Error listing namespaces by matchLabel or matchExpression: %v. Skipping namespace filtering.", err)
+		klog.Warningf("Error listing namespaces by matchLabel or matchExpression. Skipping namespace filtering. Error: %v. ", err)
 		return nil
 	}
 

--- a/pkg/informer/namespaceFilter.go
+++ b/pkg/informer/namespaceFilter.go
@@ -47,17 +47,18 @@ func (c *namespaceFilterCache) get() map[string]bool {
 	return c.allowed
 }
 
-// invalidate forces the next get() call to refresh the cache.
-func (c *namespaceFilterCache) invalidate() {
+// regenerate recomputes the namespace filter cache and resets TTL
+func (c *namespaceFilterCache) regenerate() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.expiresAt = time.Time{} // zero time is always before now
+	c.allowed = resolveCollectNamespaces()
+	c.expiresAt = time.Now().Add(time.Duration(config.Cfg.NSFilterCacheTTLMS) * time.Millisecond)
 }
 
 var nsFilterCache = &namespaceFilterCache{}
 
 // isNamespaceAllowed checks whether a resource in the given namespace should be collected.
-func isNamespaceAllowed(namespace string) bool {
+func (c *namespaceFilterCache) isNamespaceAllowed(namespace string) bool {
 	if !config.Cfg.FeatureConfigurableCollection {
 		return true
 	}
@@ -66,7 +67,9 @@ func isNamespaceAllowed(namespace string) bool {
 		return true
 	}
 
-	allowedNSMap := nsFilterCache.get()
+	allowedNSMap := c.get()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	if allowedNSMap == nil { // error in processing allowedNamespaceMap: collect everywhere
 		return true
 	}
@@ -155,7 +158,11 @@ func filterByGlobs(nsList *v1.NamespaceList, nsSelector *v1alpha1.NamespaceSelec
 }
 
 // resolveCollectNamespaces fetches the CollectorConfig and resolves the namespaceSelector
-// to a flat map of allowed namespace names. Called by nsCache.get() when the cache has expired.
+// to a flat map of allowed namespace names. Called by nsFilterCache.get() when the cache has expired.
+// three-step process:
+// 1. build a selector that ANDs matchLabels and matchExpressions, returning set of all namespaces that match
+// 2. check if include list namespaces are in the list, and if so,
+// 3. check if they should then be removed via the excludes list
 func resolveCollectNamespaces() map[string]bool {
 	if !config.Cfg.FeatureConfigurableCollection {
 		return nil

--- a/pkg/informer/namespaceFilter.go
+++ b/pkg/informer/namespaceFilter.go
@@ -22,9 +22,11 @@ import (
 // namespaceFilterCache caches the resolved namespace map with a TTL so that
 // informers don't each have to fetch and resolve the CollectorConfig.
 type namespaceFilterCache struct {
-	mu        sync.RWMutex
-	allowed   map[string]bool
-	expiresAt time.Time
+	dynamicClient dynamic.Interface
+	kubeClient    kubernetes.Interface
+	mu            sync.RWMutex
+	allowed       map[string]bool
+	expiresAt     time.Time
 }
 
 // get returns the cached namespace map, refreshing it if it has expired.
@@ -36,11 +38,6 @@ func (c *namespaceFilterCache) get() map[string]bool {
 	}
 	c.mu.RUnlock()
 
-	return c.refreshWith(config.GetDynamicClient(), config.GetKubeClient(config.GetKubeConfig()))
-}
-
-// refreshWith acquires a write lock, double-checks expiry, and resolves if still needed.
-func (c *namespaceFilterCache) refreshWith(dc dynamic.Interface, kc kubernetes.Interface) map[string]bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	// Double-check: another goroutine may have refreshed while we waited for the write lock.
@@ -48,21 +45,16 @@ func (c *namespaceFilterCache) refreshWith(dc dynamic.Interface, kc kubernetes.I
 		return c.allowed
 	}
 
-	c.allowed = resolveCollectNamespaces(dc, kc)
+	c.allowed = resolveCollectNamespaces(c.dynamicClient, c.kubeClient)
 	c.expiresAt = time.Now().Add(time.Duration(config.Cfg.NSFilterCacheTTLMS) * time.Millisecond)
 	return c.allowed
 }
 
 // regenerate recomputes the namespace filter cache and resets TTL
 func (c *namespaceFilterCache) regenerate() {
-	c.regenerateWith(config.GetDynamicClient(), config.GetKubeClient(config.GetKubeConfig()))
-}
-
-// regenerateWith recomputes the namespace filter cache with the given clients and resets TTL.
-func (c *namespaceFilterCache) regenerateWith(dc dynamic.Interface, kc kubernetes.Interface) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.allowed = resolveCollectNamespaces(dc, kc)
+	c.allowed = resolveCollectNamespaces(c.dynamicClient, c.kubeClient)
 	c.expiresAt = time.Now().Add(time.Duration(config.Cfg.NSFilterCacheTTLMS) * time.Millisecond)
 }
 

--- a/pkg/informer/namespaceFilter.go
+++ b/pkg/informer/namespaceFilter.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 )
@@ -35,6 +36,11 @@ func (c *namespaceFilterCache) get() map[string]bool {
 	}
 	c.mu.RUnlock()
 
+	return c.refreshWith(config.GetDynamicClient(), config.GetKubeClient(config.GetKubeConfig()))
+}
+
+// refreshWith acquires a write lock, double-checks expiry, and resolves if still needed.
+func (c *namespaceFilterCache) refreshWith(dc dynamic.Interface, kc kubernetes.Interface) map[string]bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	// Double-check: another goroutine may have refreshed while we waited for the write lock.
@@ -42,16 +48,21 @@ func (c *namespaceFilterCache) get() map[string]bool {
 		return c.allowed
 	}
 
-	c.allowed = resolveCollectNamespaces()
+	c.allowed = resolveCollectNamespaces(dc, kc)
 	c.expiresAt = time.Now().Add(time.Duration(config.Cfg.NSFilterCacheTTLMS) * time.Millisecond)
 	return c.allowed
 }
 
 // regenerate recomputes the namespace filter cache and resets TTL
 func (c *namespaceFilterCache) regenerate() {
+	c.regenerateWith(config.GetDynamicClient(), config.GetKubeClient(config.GetKubeConfig()))
+}
+
+// regenerateWith recomputes the namespace filter cache with the given clients and resets TTL.
+func (c *namespaceFilterCache) regenerateWith(dc dynamic.Interface, kc kubernetes.Interface) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.allowed = resolveCollectNamespaces()
+	c.allowed = resolveCollectNamespaces(dc, kc)
 	c.expiresAt = time.Now().Add(time.Duration(config.Cfg.NSFilterCacheTTLMS) * time.Millisecond)
 }
 
@@ -166,12 +177,12 @@ func filterByGlobs(nsList *v1.NamespaceList, nsSelector *v1alpha1.NamespaceSelec
 //  1. build a selector that ANDs matchLabels and matchExpressions, returning set of all namespaces that match
 //  2. check if include list namespaces are in the list, and if so,
 //  3. check if they should then be removed via the excludes list
-func resolveCollectNamespaces() map[string]bool {
+func resolveCollectNamespaces(dynamicClient dynamic.Interface, kubeClient kubernetes.Interface) map[string]bool {
 	if !config.Cfg.FeatureConfigurableCollection {
 		return nil
 	}
 
-	unstructuredConfig, err := config.GetDynamicClient().Resource(schema.GroupVersionResource{
+	unstructuredConfig, err := dynamicClient.Resource(schema.GroupVersionResource{
 		Group:    "search.open-cluster-management.io",
 		Version:  "v1alpha1",
 		Resource: "collectorconfigs",
@@ -202,7 +213,7 @@ func resolveCollectNamespaces() map[string]bool {
 	}
 
 	// List namespaces filtered by labelSelectors and matchExpressions
-	nsList, err := filterBySelectors(config.GetKubeClient(config.GetKubeConfig()), nsSelector)
+	nsList, err := filterBySelectors(kubeClient, nsSelector)
 	if err != nil {
 		klog.Warningf("Error listing namespaces by matchLabel or matchExpression. Skipping namespace filtering. Error: %v. ", err)
 		return nil

--- a/pkg/informer/namespaceFilter.go
+++ b/pkg/informer/namespaceFilter.go
@@ -71,8 +71,6 @@ func (c *namespaceFilterCache) isNamespaceAllowed(namespace string) bool {
 	}
 
 	allowedNSMap := c.get()
-	c.mu.RLock()
-	defer c.mu.RUnlock()
 	if allowedNSMap == nil { // error in processing allowedNamespaceMap: collect everywhere
 		return true
 	}

--- a/pkg/informer/namespaceFilter_test.go
+++ b/pkg/informer/namespaceFilter_test.go
@@ -1,0 +1,373 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package informer
+
+import (
+	"github.com/stolostron/search-collector/pkg/config"
+	"github.com/stolostron/search-v2-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeClient "k8s.io/client-go/kubernetes/fake"
+	"testing"
+	"time"
+)
+
+func TestFilterByGlobsIncludeNoExclude(t *testing.T) {
+	// Given: a list of namespaces: [foo, bar], include: [foo], exclude: []
+	namespaceList := &corev1.NamespaceList{
+		Items: []corev1.Namespace{
+			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
+		},
+	}
+
+	namespaceSelector := &v1alpha1.NamespaceSelector{
+		Include: []string{"foo"},
+		Exclude: []string{},
+	}
+
+	// When: we filter on namespaceList
+	result := filterByGlobs(namespaceList, namespaceSelector)
+
+	// Then: foo remains
+	assert.Equal(t, 1, len(result))
+	assert.Equal(t, true, result["foo"])
+}
+
+func TestFilterByGlobsExcludeNoInclude(t *testing.T) {
+	// Given: a list of namespaces: [foo, bar], include: [], exclude: [foo]
+	namespaceList := &corev1.NamespaceList{
+		Items: []corev1.Namespace{
+			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
+		},
+	}
+
+	namespaceSelector := &v1alpha1.NamespaceSelector{
+		Include: []string{},
+		Exclude: []string{"foo"},
+	}
+
+	// When: we filter on namespaceList
+	result := filterByGlobs(namespaceList, namespaceSelector)
+
+	// Then: bar remains
+	assert.Equal(t, 1, len(result))
+	assert.Equal(t, true, result["bar"])
+}
+
+func TestFilterByGlobsIncludeMatchExclude(t *testing.T) {
+	// Given: a list of namespaces: [foo, bar], include: [foo], exclude: [foo]
+	namespaceList := &corev1.NamespaceList{
+		Items: []corev1.Namespace{
+			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
+		},
+	}
+
+	namespaceSelector := &v1alpha1.NamespaceSelector{
+		Include: []string{"foo"},
+		Exclude: []string{"foo"},
+	}
+
+	// When: we filter on namespaceList
+	result := filterByGlobs(namespaceList, namespaceSelector)
+
+	// Then: no namespaces to collect
+	assert.Equal(t, 0, len(result))
+}
+
+func TestFilterByGlobsIncludeExclude(t *testing.T) {
+	// Given: a list of namespaces: [foo, bar], include: [foo], exclude: [bar]
+	namespaceList := &corev1.NamespaceList{
+		Items: []corev1.Namespace{
+			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
+		},
+	}
+
+	namespaceSelector := &v1alpha1.NamespaceSelector{
+		Include: []string{"foo"},
+		Exclude: []string{"bar"},
+	}
+
+	// When: we filter on namespaceList
+	result := filterByGlobs(namespaceList, namespaceSelector)
+
+	// Then: foo remains
+	assert.Equal(t, 1, len(result))
+	assert.Equal(t, true, result["foo"])
+}
+
+func TestFilterByGlobsIncludeWildcardNoExclude(t *testing.T) {
+	// Given: a list of namespaces: [foo, bar, baz], include: [ba*], exclude: []
+	namespaceList := &corev1.NamespaceList{
+		Items: []corev1.Namespace{
+			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "baz"}},
+		},
+	}
+
+	namespaceSelector := &v1alpha1.NamespaceSelector{
+		Include: []string{"ba*"},
+		Exclude: []string{},
+	}
+
+	// When: we filter on namespaceList
+	result := filterByGlobs(namespaceList, namespaceSelector)
+
+	// Then: bar and baz remain
+	assert.Equal(t, 2, len(result))
+	assert.Equal(t, true, result["bar"])
+	assert.Equal(t, true, result["baz"])
+}
+
+func TestFilterByGlobsExcludeWildcardNoInclude(t *testing.T) {
+	// Given: a list of namespaces: [foo, bar, baz], include: [], exclude: [ba*]
+	namespaceList := &corev1.NamespaceList{
+		Items: []corev1.Namespace{
+			{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "baz"}},
+		},
+	}
+
+	namespaceSelector := &v1alpha1.NamespaceSelector{
+		Include: []string{},
+		Exclude: []string{"ba*"},
+	}
+
+	// When: we filter on namespaceList
+	result := filterByGlobs(namespaceList, namespaceSelector)
+
+	// Then: foo
+	assert.Equal(t, 1, len(result))
+	assert.Equal(t, true, result["foo"])
+}
+
+func TestFilterBySelectorsMatchLabels(t *testing.T) {
+	// Given a list of namespaces: [prod-app, dev-app, no-labels], selector matching env=prod
+	fc := fakeClient.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app", Labels: map[string]string{"env": "prod"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app", Labels: map[string]string{"env": "dev"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "no-labels"}},
+	)
+
+	nsSelector := &v1alpha1.NamespaceSelector{
+		MatchLabels: map[string]string{"env": "prod"},
+	}
+
+	// When: we filter by label selectors
+	result, err := filterBySelectors(fc, nsSelector)
+
+	// Then: prod-app remains
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result.Items))
+	assert.Equal(t, "prod-app", result.Items[0].Name)
+}
+
+func TestFilterBySelectorsMatchExpressionsIn(t *testing.T) {
+	// Given a list of namespaces: [prod-app, dev-app, no-labels], selector matching env=prod
+	fc := fakeClient.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app", Labels: map[string]string{"env": "prod"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app", Labels: map[string]string{"env": "dev"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "no-labels"}},
+	)
+
+	nsSelector := &v1alpha1.NamespaceSelector{
+		MatchExpressions: []v1.LabelSelectorRequirement{
+			{Key: "env", Values: []string{"prod"}, Operator: v1.LabelSelectorOpIn},
+		},
+	}
+
+	// When: we filter by expression selectors
+	result, err := filterBySelectors(fc, nsSelector)
+
+	// Then: prod-app remains
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result.Items))
+	assert.Equal(t, "prod-app", result.Items[0].Name)
+}
+
+func TestFilterBySelectorsMatchExpressionsNotIn(t *testing.T) {
+	// Given a list of namespaces: [prod-app, dev-app, no-labels], selector matching env!=prod
+	fc := fakeClient.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app", Labels: map[string]string{"env": "prod"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app", Labels: map[string]string{"env": "dev"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "no-labels"}},
+	)
+
+	nsSelector := &v1alpha1.NamespaceSelector{
+		MatchExpressions: []v1.LabelSelectorRequirement{
+			{Key: "env", Values: []string{"prod"}, Operator: v1.LabelSelectorOpNotIn},
+		},
+	}
+
+	// When: we filter by expression selectors
+	result, err := filterBySelectors(fc, nsSelector)
+
+	// Then: dev-app and no-labels remains
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(result.Items))
+	assert.Equal(t, "dev-app", result.Items[0].Name)
+	assert.Equal(t, "no-labels", result.Items[1].Name)
+}
+
+func TestFilterBySelectorsMatchExpressionsNotInWithLabels(t *testing.T) {
+	// Given a list of namespaces: [prod-app, dev-app, no-labels], selector matching env!=prod and label env=dev
+	fc := fakeClient.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app", Labels: map[string]string{"env": "prod"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app", Labels: map[string]string{"env": "dev"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "no-labels"}},
+	)
+
+	nsSelector := &v1alpha1.NamespaceSelector{
+		MatchExpressions: []v1.LabelSelectorRequirement{
+			{Key: "env", Values: []string{"prod"}, Operator: v1.LabelSelectorOpNotIn},
+		},
+		MatchLabels: map[string]string{"env": "dev"},
+	}
+
+	// When: we filter by expression selectors
+	result, err := filterBySelectors(fc, nsSelector)
+
+	// Then: dev-app remains
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result.Items))
+	assert.Equal(t, "dev-app", result.Items[0].Name)
+}
+
+func TestFilterBySelectorsThenGlobs(t *testing.T) {
+	// Given a list of namespaces: [prod-app, dev-app, dev-app-2, no-labels], selector matching env!=prod and label env=dev and glob Include:[dev-*]
+	fc := fakeClient.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app", Labels: map[string]string{"env": "prod"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app", Labels: map[string]string{"env": "dev"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app-2", Labels: map[string]string{"env": "dev"}}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "no-labels"}},
+	)
+
+	nsSelector := &v1alpha1.NamespaceSelector{
+		MatchExpressions: []v1.LabelSelectorRequirement{
+			{Key: "env", Values: []string{"prod"}, Operator: v1.LabelSelectorOpNotIn},
+		},
+		MatchLabels: map[string]string{"env": "dev"},
+		Include:     []string{"dev-*"},
+		Exclude:     []string{},
+	}
+
+	// When: we filter by expression selectors and glob
+	interim, err := filterBySelectors(fc, nsSelector)
+	result := filterByGlobs(interim, nsSelector)
+
+	// Then: dev-app and dev-app-2 remain
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(result))
+	assert.Equal(t, true, result["dev-app"])
+	assert.Equal(t, true, result["dev-app-2"])
+}
+
+func TestFilterByEmptySelectors(t *testing.T) {
+	// Given: a list of namespaces: [foo, bar, baz] with no filters
+	fc := fakeClient.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bar"}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "baz"}},
+	)
+	namespaceSelector := &v1alpha1.NamespaceSelector{}
+
+	// When: we filter on namespaceList
+	interim, err := filterBySelectors(fc, namespaceSelector)
+	result := filterByGlobs(interim, namespaceSelector)
+
+	// Then: foo, bar, and baz remain
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(result))
+	assert.Equal(t, true, result["foo"])
+	assert.Equal(t, true, result["bar"])
+	assert.Equal(t, true, result["baz"])
+}
+
+// setNSFilterCache sets the namespace cache for testing and returns a cleanup function.
+func setNSFilterCache(allowed map[string]bool) func() {
+	origAllowed := nsFilterCache.allowed
+	origExpiry := nsFilterCache.expiresAt
+	nsFilterCache.allowed = allowed
+	nsFilterCache.expiresAt = time.Now().Add(10 * time.Minute) // won't expire during test
+	return func() {
+		nsFilterCache.allowed = origAllowed
+		nsFilterCache.expiresAt = origExpiry
+	}
+}
+
+// Feature flag disabled: allow everything regardless of cache contents.
+func TestIsNamespaceAllowed_FeatureDisabled(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = false
+
+	defer setNSFilterCache(nil)()
+	assert.True(t, isNamespaceAllowed("any-ns"))
+
+	defer setNSFilterCache(map[string]bool{})()
+	assert.True(t, isNamespaceAllowed("any-ns"))
+
+	defer setNSFilterCache(map[string]bool{"other": true})()
+	assert.True(t, isNamespaceAllowed("any-ns"))
+}
+
+// Nil map means no filter was configured: allow all namespaces.
+func TestIsNamespaceAllowed_NilMap(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = true
+
+	defer setNSFilterCache(nil)()
+	assert.True(t, isNamespaceAllowed("any-ns"))
+}
+
+// Empty map means selector matched zero namespaces: block everything.
+func TestIsNamespaceAllowed_EmptyMap(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = true
+
+	defer setNSFilterCache(map[string]bool{})()
+	assert.False(t, isNamespaceAllowed("any-ns"))
+}
+
+// Cluster-scoped resources (empty namespace) always pass.
+func TestIsNamespaceAllowed_ClusterScoped(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = true
+
+	defer setNSFilterCache(map[string]bool{"ns1": true})()
+	assert.True(t, isNamespaceAllowed(""))
+
+	defer setNSFilterCache(map[string]bool{})()
+	assert.True(t, isNamespaceAllowed(""))
+}
+
+// Namespace in the allowed map passes.
+func TestIsNamespaceAllowed_Allowed(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = true
+
+	defer setNSFilterCache(map[string]bool{"ns1": true, "ns2": true})()
+	assert.True(t, isNamespaceAllowed("ns1"))
+	assert.True(t, isNamespaceAllowed("ns2"))
+}
+
+// Namespace not in the allowed map is blocked.
+func TestIsNamespaceAllowed_NotAllowed(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = true
+
+	defer setNSFilterCache(map[string]bool{"ns1": true})()
+	assert.False(t, isNamespaceAllowed("ns2"))
+	assert.False(t, isNamespaceAllowed("kube-system"))
+}

--- a/pkg/informer/namespaceFilter_test.go
+++ b/pkg/informer/namespaceFilter_test.go
@@ -3,14 +3,19 @@
 package informer
 
 import (
+	"testing"
+	"time"
+
 	"github.com/stolostron/search-collector/pkg/config"
 	"github.com/stolostron/search-v2-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicFake "k8s.io/client-go/dynamic/fake"
 	fakeClient "k8s.io/client-go/kubernetes/fake"
-	"testing"
-	"time"
 )
 
 func TestFilterByGlobsIncludeNoExclude(t *testing.T) {
@@ -301,6 +306,77 @@ func setNSFilterCache(allowed map[string]bool) func() {
 	}
 }
 
+// refreshWith resolves and caches the result.
+func TestRefreshWith(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = true
+
+	origNS := config.Cfg.PodNamespace
+	defer func() { config.Cfg.PodNamespace = origNS }()
+	config.Cfg.PodNamespace = "open-cluster-management"
+	config.Cfg.NSFilterCacheTTLMS = 300000
+
+	dc := fakeDynamicClientWithCollectorConfig(map[string]interface{}{
+		"include": []interface{}{"prod-*"},
+	})
+	kc := fakeClient.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app"}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app"}},
+	)
+
+	c := &namespaceFilterCache{}
+
+	result := c.refreshWith(dc, kc)
+	assert.Equal(t, map[string]bool{"prod-app": true}, result)
+	assert.True(t, time.Now().Before(c.expiresAt), "expiresAt should be set in the future")
+}
+
+// refreshWith skips resolve if another goroutine already refreshed (double-check path).
+func TestRefreshWith_DoubleCheck(t *testing.T) {
+	config.Cfg.NSFilterCacheTTLMS = 300000
+
+	c := &namespaceFilterCache{
+		allowed:   map[string]bool{"already-refreshed": true},
+		expiresAt: time.Now().Add(10 * time.Minute),
+	}
+
+	// Clients are nil — they should never be used since the cache is still valid.
+	result := c.refreshWith(nil, nil)
+	assert.Equal(t, map[string]bool{"already-refreshed": true}, result)
+}
+
+// regenerate() refreshes cache and resets TTL.
+func TestRegenerate(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = true
+
+	origNS := config.Cfg.PodNamespace
+	defer func() { config.Cfg.PodNamespace = origNS }()
+	config.Cfg.PodNamespace = "open-cluster-management"
+	config.Cfg.NSFilterCacheTTLMS = 300000
+
+	dc := fakeDynamicClientWithCollectorConfig(map[string]interface{}{
+		"include": []interface{}{"ns-*"},
+	})
+	kc := fakeClient.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "ns-one"}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "ns-two"}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "other"}},
+	)
+
+	c := &namespaceFilterCache{
+		allowed:   map[string]bool{"old": true},
+		expiresAt: time.Now().Add(10 * time.Minute),
+	}
+
+	c.regenerateWith(dc, kc)
+
+	assert.Equal(t, map[string]bool{"ns-one": true, "ns-two": true}, c.allowed)
+	assert.True(t, time.Now().Before(c.expiresAt))
+}
+
 // Feature flag disabled: allow everything regardless of cache contents.
 func TestIsNamespaceAllowed_FeatureDisabled(t *testing.T) {
 	original := config.Cfg.FeatureConfigurableCollection
@@ -370,4 +446,130 @@ func TestIsNamespaceAllowed_NotAllowed(t *testing.T) {
 	defer setNSFilterCache(map[string]bool{"ns1": true})()
 	assert.False(t, nsFilterCache.isNamespaceAllowed("ns2"))
 	assert.False(t, nsFilterCache.isNamespaceAllowed("kube-system"))
+}
+
+var collectorConfigGVR = schema.GroupVersionResource{
+	Group:    "search.open-cluster-management.io",
+	Version:  "v1alpha1",
+	Resource: "collectorconfigs",
+}
+
+// Helper to build a fake dynamic client seeded with a CollectorConfig CR.
+func fakeDynamicClientWithCollectorConfig(nsSelector map[string]interface{}) *dynamicFake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+
+	spec := map[string]interface{}{}
+	if nsSelector != nil {
+		spec["collectNamespaces"] = map[string]interface{}{
+			"namespaceSelector": nsSelector,
+		}
+	}
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "collector-config",
+				"namespace": "open-cluster-management",
+			},
+			"spec": spec,
+		},
+	}
+
+	return dynamicFake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			collectorConfigGVR: "CollectorConfigList",
+		},
+		obj,
+	)
+}
+
+// Feature disabled: returns nil.
+func TestResolveCollectNamespaces_FeatureDisabled(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = false
+
+	result := resolveCollectNamespaces(nil, nil)
+	assert.Nil(t, result)
+}
+
+// CollectorConfig not found: returns nil (collect everywhere).
+func TestResolveCollectNamespaces_ConfigNotFound(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = true
+
+	origNS := config.Cfg.PodNamespace
+	defer func() { config.Cfg.PodNamespace = origNS }()
+	config.Cfg.PodNamespace = "open-cluster-management"
+
+	// Empty dynamic client — no CollectorConfig exists
+	scheme := runtime.NewScheme()
+	dc := dynamicFake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			collectorConfigGVR: "CollectorConfigList",
+		},
+	)
+
+	result := resolveCollectNamespaces(dc, nil)
+	assert.Nil(t, result)
+}
+
+// CollectorConfig with no namespaceSelector: returns nil (collect everywhere).
+func TestResolveCollectNamespaces_NoNamespaceSelector(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = true
+
+	origNS := config.Cfg.PodNamespace
+	defer func() { config.Cfg.PodNamespace = origNS }()
+	config.Cfg.PodNamespace = "open-cluster-management"
+
+	dc := fakeDynamicClientWithCollectorConfig(nil)
+
+	result := resolveCollectNamespaces(dc, nil)
+	assert.Nil(t, result)
+}
+
+// CollectorConfig with empty namespaceSelector: returns nil (collect everywhere).
+func TestResolveCollectNamespaces_EmptySelector(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = true
+
+	origNS := config.Cfg.PodNamespace
+	defer func() { config.Cfg.PodNamespace = origNS }()
+	config.Cfg.PodNamespace = "open-cluster-management"
+
+	dc := fakeDynamicClientWithCollectorConfig(map[string]interface{}{})
+
+	result := resolveCollectNamespaces(dc, nil)
+	assert.Nil(t, result)
+}
+
+// CollectorConfig with include glob: resolves filtered namespaces.
+func TestResolveCollectNamespaces_WithInclude(t *testing.T) {
+	original := config.Cfg.FeatureConfigurableCollection
+	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
+	config.Cfg.FeatureConfigurableCollection = true
+
+	origNS := config.Cfg.PodNamespace
+	defer func() { config.Cfg.PodNamespace = origNS }()
+	config.Cfg.PodNamespace = "open-cluster-management"
+
+	dc := fakeDynamicClientWithCollectorConfig(map[string]interface{}{
+		"include": []interface{}{"prod-*"},
+	})
+	kc := fakeClient.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app"}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-db"}},
+		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app"}},
+	)
+
+	result := resolveCollectNamespaces(dc, kc)
+	assert.Equal(t, 2, len(result))
+	assert.True(t, result["prod-app"])
+	assert.True(t, result["prod-db"])
 }

--- a/pkg/informer/namespaceFilter_test.go
+++ b/pkg/informer/namespaceFilter_test.go
@@ -306,8 +306,8 @@ func setNSFilterCache(allowed map[string]bool) func() {
 	}
 }
 
-// refreshWith resolves and caches the result.
-func TestRefreshWith(t *testing.T) {
+// get() refreshes the cache on miss using clients from the struct.
+func TestGet_CacheMiss(t *testing.T) {
 	original := config.Cfg.FeatureConfigurableCollection
 	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
 	config.Cfg.FeatureConfigurableCollection = true
@@ -317,36 +317,22 @@ func TestRefreshWith(t *testing.T) {
 	config.Cfg.PodNamespace = "open-cluster-management"
 	config.Cfg.NSFilterCacheTTLMS = 300000
 
-	dc := fakeDynamicClientWithCollectorConfig(map[string]interface{}{
-		"include": []interface{}{"prod-*"},
-	})
-	kc := fakeClient.NewSimpleClientset(
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app"}},
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app"}},
-	)
+	c := &namespaceFilterCache{
+		dynamicClient: fakeDynamicClientWithCollectorConfig(map[string]interface{}{
+			"include": []interface{}{"prod-*"},
+		}),
+		kubeClient: fakeClient.NewSimpleClientset(
+			&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "prod-app"}},
+			&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "dev-app"}},
+		),
+	}
 
-	c := &namespaceFilterCache{}
-
-	result := c.refreshWith(dc, kc)
+	result := c.get()
 	assert.Equal(t, map[string]bool{"prod-app": true}, result)
 	assert.True(t, time.Now().Before(c.expiresAt), "expiresAt should be set in the future")
 }
 
-// refreshWith skips resolve if another goroutine already refreshed (double-check path).
-func TestRefreshWith_DoubleCheck(t *testing.T) {
-	config.Cfg.NSFilterCacheTTLMS = 300000
-
-	c := &namespaceFilterCache{
-		allowed:   map[string]bool{"already-refreshed": true},
-		expiresAt: time.Now().Add(10 * time.Minute),
-	}
-
-	// Clients are nil — they should never be used since the cache is still valid.
-	result := c.refreshWith(nil, nil)
-	assert.Equal(t, map[string]bool{"already-refreshed": true}, result)
-}
-
-// regenerate() refreshes cache and resets TTL.
+// regenerate() refreshes cache and resets TTL using clients from the struct.
 func TestRegenerate(t *testing.T) {
 	original := config.Cfg.FeatureConfigurableCollection
 	defer func() { config.Cfg.FeatureConfigurableCollection = original }()
@@ -357,21 +343,20 @@ func TestRegenerate(t *testing.T) {
 	config.Cfg.PodNamespace = "open-cluster-management"
 	config.Cfg.NSFilterCacheTTLMS = 300000
 
-	dc := fakeDynamicClientWithCollectorConfig(map[string]interface{}{
-		"include": []interface{}{"ns-*"},
-	})
-	kc := fakeClient.NewSimpleClientset(
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "ns-one"}},
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "ns-two"}},
-		&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "other"}},
-	)
-
 	c := &namespaceFilterCache{
+		dynamicClient: fakeDynamicClientWithCollectorConfig(map[string]interface{}{
+			"include": []interface{}{"ns-*"},
+		}),
+		kubeClient: fakeClient.NewSimpleClientset(
+			&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "ns-one"}},
+			&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "ns-two"}},
+			&corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "other"}},
+		),
 		allowed:   map[string]bool{"old": true},
 		expiresAt: time.Now().Add(10 * time.Minute),
 	}
 
-	c.regenerateWith(dc, kc)
+	c.regenerate()
 
 	assert.Equal(t, map[string]bool{"ns-one": true, "ns-two": true}, c.allowed)
 	assert.True(t, time.Now().Before(c.expiresAt))

--- a/pkg/informer/namespaceFilter_test.go
+++ b/pkg/informer/namespaceFilter_test.go
@@ -308,13 +308,13 @@ func TestIsNamespaceAllowed_FeatureDisabled(t *testing.T) {
 	config.Cfg.FeatureConfigurableCollection = false
 
 	defer setNSFilterCache(nil)()
-	assert.True(t, isNamespaceAllowed("any-ns"))
+	assert.True(t, nsFilterCache.isNamespaceAllowed("any-ns"))
 
 	defer setNSFilterCache(map[string]bool{})()
-	assert.True(t, isNamespaceAllowed("any-ns"))
+	assert.True(t, nsFilterCache.isNamespaceAllowed("any-ns"))
 
 	defer setNSFilterCache(map[string]bool{"other": true})()
-	assert.True(t, isNamespaceAllowed("any-ns"))
+	assert.True(t, nsFilterCache.isNamespaceAllowed("any-ns"))
 }
 
 // Nil map means no filter was configured: allow all namespaces.
@@ -324,7 +324,7 @@ func TestIsNamespaceAllowed_NilMap(t *testing.T) {
 	config.Cfg.FeatureConfigurableCollection = true
 
 	defer setNSFilterCache(nil)()
-	assert.True(t, isNamespaceAllowed("any-ns"))
+	assert.True(t, nsFilterCache.isNamespaceAllowed("any-ns"))
 }
 
 // Empty map means selector matched zero namespaces: block everything.
@@ -334,7 +334,7 @@ func TestIsNamespaceAllowed_EmptyMap(t *testing.T) {
 	config.Cfg.FeatureConfigurableCollection = true
 
 	defer setNSFilterCache(map[string]bool{})()
-	assert.False(t, isNamespaceAllowed("any-ns"))
+	assert.False(t, nsFilterCache.isNamespaceAllowed("any-ns"))
 }
 
 // Cluster-scoped resources (empty namespace) always pass.
@@ -344,10 +344,10 @@ func TestIsNamespaceAllowed_ClusterScoped(t *testing.T) {
 	config.Cfg.FeatureConfigurableCollection = true
 
 	defer setNSFilterCache(map[string]bool{"ns1": true})()
-	assert.True(t, isNamespaceAllowed(""))
+	assert.True(t, nsFilterCache.isNamespaceAllowed(""))
 
 	defer setNSFilterCache(map[string]bool{})()
-	assert.True(t, isNamespaceAllowed(""))
+	assert.True(t, nsFilterCache.isNamespaceAllowed(""))
 }
 
 // Namespace in the allowed map passes.
@@ -357,8 +357,8 @@ func TestIsNamespaceAllowed_Allowed(t *testing.T) {
 	config.Cfg.FeatureConfigurableCollection = true
 
 	defer setNSFilterCache(map[string]bool{"ns1": true, "ns2": true})()
-	assert.True(t, isNamespaceAllowed("ns1"))
-	assert.True(t, isNamespaceAllowed("ns2"))
+	assert.True(t, nsFilterCache.isNamespaceAllowed("ns1"))
+	assert.True(t, nsFilterCache.isNamespaceAllowed("ns2"))
 }
 
 // Namespace not in the allowed map is blocked.
@@ -368,6 +368,6 @@ func TestIsNamespaceAllowed_NotAllowed(t *testing.T) {
 	config.Cfg.FeatureConfigurableCollection = true
 
 	defer setNSFilterCache(map[string]bool{"ns1": true})()
-	assert.False(t, isNamespaceAllowed("ns2"))
-	assert.False(t, isNamespaceAllowed("kube-system"))
+	assert.False(t, nsFilterCache.isNamespaceAllowed("ns2"))
+	assert.False(t, nsFilterCache.isNamespaceAllowed("kube-system"))
 }

--- a/pkg/informer/runInformers.go
+++ b/pkg/informer/runInformers.go
@@ -447,6 +447,12 @@ func RunInformers(
 		}
 	}()
 
+	if config.Cfg.FeatureConfigurableCollection {
+		// init clients for use by namespaceFilter
+		nsFilterCache.dynamicClient = config.GetDynamicClient()
+		nsFilterCache.kubeClient = config.GetKubeClient(config.GetKubeConfig())
+	}
+
 	syncInformersQueue := workqueue.NewTypedWithConfig(workqueue.QueueConfig{})
 	defer syncInformersQueue.ShutDown()
 


### PR DESCRIPTION
### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-21531

### Description of changes
- Parses informer events, filters namespace from CollectorConfig's NamespaceSelector.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Namespace allowlisting for resource collection, resolved at runtime with a TTL-based cache; falls back to “allow all” if collection is disabled or config errors occur.
  * Two-stage filtering: selectors (labels/expressions) then include/exclude glob patterns; cluster-scoped resources always allowed.

* **Bug Fixes**
  * Initial cache now keeps only allowed namespaces and removes previously-cached disallowed resources.
  * Runtime processing skips ADDED/MODIFIED/DELETED events for disallowed namespaces.

* **Tests**
  * Expanded unit tests covering selector/glob filtering, combined flows, and allowlist gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->