### PR TITLE
pin gosec version 2.22.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ lint:
 	GOPATH=$(go env GOPATH)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.4.0
 	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=3m
+	curl -sSfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.22.4
 	gosec ./...
 	
 run:

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -11,6 +11,7 @@ lint:
 	GOPATH=$(go env GOPATH)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.4.0
 	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=3m
+	curl -sSfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.22.4
 	gosec ./...
 	
 .PHONY: unit-test


### PR DESCRIPTION
### Description of changes
- Use specific gosec for CI stability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline to automatically install required tools during the lint phase, ensuring all necessary dependencies are available before checks execute in both standard and Prow-based build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->