### PR TITLE
Add metrics for sync timeout and resync track

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -21,4 +21,10 @@ var (
 		Name: "search_collector_resources_sent_to_indexer_count",
 		Help: "Total resources sent to indexer after reconciliation",
 	}, []string{"resource_kind"})
+
+	// SyncRequestTotal total number of HTTP requests sent to indexer
+	SyncRequestTotal = promauto.With(PromRegistry).NewCounterVec(prometheus.CounterOpts{
+		Name: "search_collector_sync_requests_total",
+		Help: "Total number of HTTP requests sent",
+	}, []string{"status_code", "sync_type"})
 )

--- a/pkg/send/sender.go
+++ b/pkg/send/sender.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/stolostron/search-collector/pkg/config"
+	"github.com/stolostron/search-collector/pkg/metrics"
 	"github.com/stolostron/search-collector/pkg/reconciler"
 	tr "github.com/stolostron/search-collector/pkg/transforms"
 )
@@ -186,6 +187,11 @@ func (s *Sender) send(payload Payload, expectedTotalResources int, expectedTotal
 		len(payload.AddResources), len(payload.UpdatedResources), len(payload.DeletedResources),
 		len(payload.AddEdges), len(payload.DeleteEdges))
 
+	syncType := "sync"
+	if payload.ClearAll {
+		syncType = "resync"
+	}
+
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		return err
@@ -211,6 +217,8 @@ func (s *Sender) send(payload Payload, expectedTotalResources int, expectedTotal
 		klog.Error("httpClient error: ", err)
 		return err
 	}
+
+	metrics.SyncRequestTotal.WithLabelValues(strconv.Itoa(resp.StatusCode), syncType).Inc()
 	if resp.StatusCode == http.StatusTooManyRequests {
 		return errors.New("indexer busy")
 	} else if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION

### Description of changes
Add metrics to the search-collector to improve observability of sync failures:

- `search_collector_sync_timeout_total` — Incremented when the collector receives a 504 Gateway Timeout from the aggregated API proxy, indicates the sync request exceeded the 60s timeout.
- `search_collector_resync_total` — Incremented when a diff sync fails and the collector escalates to a complete resync payload.

Large managed clusters (200k+ resources) can exceed the 60 second aggregated API timeout during complete resync, causing the collector to enter an infinite retry loop. The only supported remediation is restarting the search-postgres pod (RH KB https://access.redhat.com/solutions/7134528)

Currently there is no metric to detect this condition, only checking logs can identify affected clusters.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring for sync requests: a new counter tracks total sync HTTP requests, recording response status codes and whether the attempt was a sync or resync. This improves visibility into sync activity and outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->