### PR TITLE
ACM-30764: Store boolean resource properties as strings

### DIFF
--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -826,12 +826,10 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 					if len(interfaceSlice) > 0 {
 						node.Properties[prop.Name] = interfaceSlice
 					}
+				} else if b, ok := val.(bool); ok { // convert bool to string
+					node.Properties[prop.Name] = strconv.FormatBool(b)
 				} else {
-					if b, ok := val.(bool); ok { // convert bool to string
-						node.Properties[prop.Name] = strconv.FormatBool(b)
-					} else {
-						node.Properties[prop.Name] = val
-					}
+					node.Properties[prop.Name] = val
 				}
 			}
 		} else {

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -827,7 +827,11 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 						node.Properties[prop.Name] = interfaceSlice
 					}
 				} else {
-					node.Properties[prop.Name] = val
+					if b, ok := val.(bool); ok { // convert bool to string
+						node.Properties[prop.Name] = strconv.FormatBool(b)
+					} else {
+						node.Properties[prop.Name] = val
+					}
 				}
 			}
 		} else {

--- a/pkg/transforms/cronjob.go
+++ b/pkg/transforms/cronjob.go
@@ -11,6 +11,7 @@ Copyright (c) 2020 Red Hat, Inc.
 package transforms
 
 import (
+	"strconv"
 	"time"
 
 	v1 "k8s.io/api/batch/v1beta1"
@@ -33,10 +34,11 @@ func CronJobResourceBuilder(c *v1.CronJob) *CronJobResource {
 	if c.Status.LastScheduleTime != nil {
 		node.Properties["lastSchedule"] = c.Status.LastScheduleTime.UTC().Format(time.RFC3339)
 	}
-	node.Properties["suspend"] = false
+	suspend := false
 	if c.Spec.Suspend != nil {
-		node.Properties["suspend"] = *c.Spec.Suspend
+		suspend = *c.Spec.Suspend
 	}
+	node.Properties["suspend"] = strconv.FormatBool(suspend)
 
 	return &CronJobResource{node: node}
 }

--- a/pkg/transforms/cronjob_test.go
+++ b/pkg/transforms/cronjob_test.go
@@ -30,7 +30,37 @@ func TestTransformCronJob(t *testing.T) {
 	AssertEqual("active", node.Properties["active"], int64(0), t)
 	AssertEqual("lastSchedule", node.Properties["lastSchedule"], date.UTC().Format(time.RFC3339), t)
 	AssertEqual("schedule", node.Properties["schedule"], "30 23 * * *", t)
-	AssertEqual("suspend", node.Properties["suspend"], false, t)
+	AssertEqual("suspend", node.Properties["suspend"], "false", t)
+}
+
+// TestBooleanFieldsStoredAsStrings_CronJob verifies that the suspend field on
+// CronJob is stored as a string so the search API can query it correctly.
+func TestBooleanFieldsStoredAsStrings_CronJob(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	tests := []struct {
+		name     string
+		suspend  *bool
+		expected string
+	}{
+		{"nil pointer defaults to false", nil, "false"},
+		{"false pointer", &falseVal, "false"},
+		{"true pointer", &trueVal, "true"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := v1.CronJob{}
+			c.Spec.Suspend = tc.suspend
+			node := CronJobResourceBuilder(&c).BuildNode()
+			val, ok := node.Properties["suspend"].(string)
+			if !ok {
+				t.Fatalf("suspend should be a string, got %T: %v", node.Properties["suspend"], node.Properties["suspend"])
+			}
+			AssertEqual("suspend", val, tc.expected, t)
+		})
+	}
 }
 
 func TestCronJobBuildEdges(t *testing.T) {

--- a/pkg/transforms/genericResource_test.go
+++ b/pkg/transforms/genericResource_test.go
@@ -3,6 +3,7 @@
 package transforms
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stolostron/search-collector/pkg/config"
@@ -166,7 +167,7 @@ func Test_genericResourceFromConfigVM(t *testing.T) {
 	AssertEqual("runStrategy", node.Properties["runStrategy"], "always", t)
 	AssertEqual("status", node.Properties["status"], "Running", t)
 	AssertEqual("workload", node.Properties["workload"], "server", t)
-	AssertEqual("_specRunning", node.Properties["_specRunning"], true, t)
+	AssertEqual("_specRunning", node.Properties["_specRunning"], "true", t)
 	AssertEqual("_specRunStrategy", node.Properties["_specRunStrategy"], "always", t)
 }
 
@@ -244,7 +245,7 @@ func Test_genericResourceFromConfigVMSnapshot(t *testing.T) {
 	AssertEqual("ready", node.Properties["ready"], "True", t)
 	AssertEqual("_conditionReadyReason", node.Properties["_conditionReadyReason"], "Operation complete", t)
 	AssertEqual("phase", node.Properties["phase"], "Succeeded", t)
-	AssertEqual("readyToUse", node.Properties["readyToUse"], true, t)
+	AssertEqual("readyToUse", node.Properties["readyToUse"], "true", t)
 	AssertEqual("sourceName", node.Properties["sourceName"], "centos7-gray-owl-35", t)
 	AssertEqual("sourceKind", node.Properties["sourceKind"], "VirtualMachine", t)
 	AssertDeepEqual("indications", node.Properties["indications"], []interface{}{"Online", "NoGuestAgent"}, t)
@@ -269,7 +270,7 @@ func Test_genericResourceFromConfigVMRestore(t *testing.T) {
 	// Verify properties defined in the transform config
 	AssertEqual("ready", node.Properties["ready"], "True", t)
 	AssertEqual("_conditionReadyReason", node.Properties["_conditionReadyReason"], "Operation complete", t)
-	AssertEqual("complete", node.Properties["complete"], true, t)
+	AssertEqual("complete", node.Properties["complete"], "true", t)
 	AssertEqual("targetApiGroup", node.Properties["targetApiGroup"], "kubevirt.io", t)
 	AssertEqual("targetName", node.Properties["targetName"], "centos7-gray-owl-35", t)
 	AssertEqual("targetKind", node.Properties["targetKind"], "VirtualMachine", t)
@@ -329,7 +330,7 @@ func Test_genericResourceFromConfigStorageClass(t *testing.T) {
 	AssertEqual("created", node.Properties["created"], "2025-03-11T10:24:44Z", t)
 
 	// Verify properties defined in the transform config
-	AssertEqual("allowVolumeExpansion", node.Properties["allowVolumeExpansion"], true, t)
+	AssertEqual("allowVolumeExpansion", node.Properties["allowVolumeExpansion"], "true", t)
 	AssertEqual("provisioner", node.Properties["provisioner"], "ebs.csi.aws.com", t)
 	AssertEqual("reclaimPolicy", node.Properties["reclaimPolicy"], "Delete", t)
 	AssertEqual("volumeBindingMode", node.Properties["volumeBindingMode"], "WaitForFirstConsumer", t)
@@ -512,8 +513,8 @@ func Test_genericResourceFromConfigMigrationPolicy(t *testing.T) {
 	AssertEqual("created", node.Properties["created"], "2025-12-15T12:00:00Z", t)
 
 	// Verify properties defined in the transform config
-	AssertEqual("allowAutoConverge", node.Properties["allowAutoConverge"], true, t)
-	AssertEqual("allowPostCopy", node.Properties["allowPostCopy"], false, t)
+	AssertEqual("allowAutoConverge", node.Properties["allowAutoConverge"], "true", t)
+	AssertEqual("allowPostCopy", node.Properties["allowPostCopy"], "false", t)
 	AssertEqual("bandwidthPerMigration", node.Properties["bandwidthPerMigration"], int64(67108864), t)
 	AssertEqual("completionTimeoutPerGiB", node.Properties["completionTimeoutPerGiB"], int64(120), t)
 	AssertDeepEqual("annotation", node.Properties["annotation"], map[string]string{
@@ -651,4 +652,201 @@ func Test_genericResourceFromConfigTemplateNoMatchLabel(t *testing.T) {
 	// Verify properties defined in the transform config aren't present because they don't match label
 	AssertEqual("objectVMArchitecture", node.Properties["objectVMArchitecture"], nil, t)
 	AssertEqual("objectVMName", node.Properties["objectVMName"], nil, t)
+}
+
+// TestBooleanFieldsStoredAsStrings_GenericConfig verifies that boolean fields
+// extracted via genericResourceConfig (using DataType: DataTypeString) are stored
+// as their string representations so the search API can query them correctly.
+func TestBooleanFieldsStoredAsStrings_GenericConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource *unstructured.Unstructured
+		field    string
+		expected string
+	}{
+		{
+			name:     "StorageClass allowVolumeExpansion=true",
+			field:    "allowVolumeExpansion",
+			expected: "true",
+			resource: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "storage.k8s.io/v1", "kind": "StorageClass",
+				"metadata":             map[string]interface{}{"name": "test"},
+				"allowVolumeExpansion": true,
+			}},
+		},
+		{
+			name:     "StorageClass allowVolumeExpansion=false",
+			field:    "allowVolumeExpansion",
+			expected: "false",
+			resource: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "storage.k8s.io/v1", "kind": "StorageClass",
+				"metadata":             map[string]interface{}{"name": "test"},
+				"allowVolumeExpansion": false,
+			}},
+		},
+		{
+			name:     "MigrationPolicy allowAutoConverge=true",
+			field:    "allowAutoConverge",
+			expected: "true",
+			resource: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "migrations.kubevirt.io/v1alpha1", "kind": "MigrationPolicy",
+				"metadata": map[string]interface{}{"name": "test"},
+				"spec":     map[string]interface{}{"allowAutoConverge": true},
+			}},
+		},
+		{
+			name:     "MigrationPolicy allowAutoConverge=false",
+			field:    "allowAutoConverge",
+			expected: "false",
+			resource: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "migrations.kubevirt.io/v1alpha1", "kind": "MigrationPolicy",
+				"metadata": map[string]interface{}{"name": "test"},
+				"spec":     map[string]interface{}{"allowAutoConverge": false},
+			}},
+		},
+		{
+			name:     "MigrationPolicy allowPostCopy=true",
+			field:    "allowPostCopy",
+			expected: "true",
+			resource: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "migrations.kubevirt.io/v1alpha1", "kind": "MigrationPolicy",
+				"metadata": map[string]interface{}{"name": "test"},
+				"spec":     map[string]interface{}{"allowPostCopy": true},
+			}},
+		},
+		{
+			name:     "MigrationPolicy allowPostCopy=false",
+			field:    "allowPostCopy",
+			expected: "false",
+			resource: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "migrations.kubevirt.io/v1alpha1", "kind": "MigrationPolicy",
+				"metadata": map[string]interface{}{"name": "test"},
+				"spec":     map[string]interface{}{"allowPostCopy": false},
+			}},
+		},
+		{
+			name:     "VirtualMachineSnapshot readyToUse=true",
+			field:    "readyToUse",
+			expected: "true",
+			resource: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "snapshot.kubevirt.io/v1beta1", "kind": "VirtualMachineSnapshot",
+				"metadata": map[string]interface{}{"name": "test"},
+				"status":   map[string]interface{}{"readyToUse": true},
+			}},
+		},
+		{
+			name:     "VirtualMachineSnapshot readyToUse=false",
+			field:    "readyToUse",
+			expected: "false",
+			resource: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "snapshot.kubevirt.io/v1beta1", "kind": "VirtualMachineSnapshot",
+				"metadata": map[string]interface{}{"name": "test"},
+				"status":   map[string]interface{}{"readyToUse": false},
+			}},
+		},
+		{
+			name:     "VirtualMachineRestore complete=true",
+			field:    "complete",
+			expected: "true",
+			resource: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "snapshot.kubevirt.io/v1beta1", "kind": "VirtualMachineRestore",
+				"metadata": map[string]interface{}{"name": "test"},
+				"status":   map[string]interface{}{"complete": true},
+			}},
+		},
+		{
+			name:     "VirtualMachineRestore complete=false",
+			field:    "complete",
+			expected: "false",
+			resource: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "snapshot.kubevirt.io/v1beta1", "kind": "VirtualMachineRestore",
+				"metadata": map[string]interface{}{"name": "test"},
+				"status":   map[string]interface{}{"complete": false},
+			}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			node := GenericResourceBuilder(tc.resource).BuildNode()
+			val, ok := node.Properties[tc.field].(string)
+			if !ok {
+				t.Fatalf("%s should be a string, got %T: %v",
+					tc.field, node.Properties[tc.field], node.Properties[tc.field])
+			}
+			AssertEqual(tc.field, val, tc.expected, t)
+		})
+	}
+}
+
+// TestBooleanFieldsNotStoredAsRawBool_RegressionPrevention is a regression test
+// that explicitly documents WHY booleans must be stored as strings.
+//
+// The search API queries JSONB fields using the '?' key-exists operator, which
+// only matches string keys inside a JSONB object. A raw JSON boolean (true/false)
+// is NOT a key and cannot be found by the '?' operator. Storing booleans as
+// strings ("true"/"false") makes them queryable as:
+//
+//   WHERE data->'allowVolumeExpansion' ? 'true'   -- works for string "true"
+//
+// If a value were stored as a raw boolean, that SQL would return 0 rows even
+// though the field is set. This test prevents that regression by asserting:
+// 1. The stored type is string, not bool.
+// 2. The stored value equals the expected string ("true" or "false").
+func TestBooleanFieldsNotStoredAsRawBool_RegressionPrevention(t *testing.T) {
+	fields := []struct {
+		resource *unstructured.Unstructured
+		field    string
+		rawBool  bool
+	}{
+		{
+			field:   "allowVolumeExpansion",
+			rawBool: true,
+			resource: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "storage.k8s.io/v1", "kind": "StorageClass",
+				"metadata": map[string]interface{}{"name": "test"}, "allowVolumeExpansion": true,
+			}},
+		},
+		{
+			field:   "readyToUse",
+			rawBool: true,
+			resource: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "snapshot.kubevirt.io/v1beta1", "kind": "VirtualMachineSnapshot",
+				"metadata": map[string]interface{}{"name": "test"},
+				"status":   map[string]interface{}{"readyToUse": true},
+			}},
+		},
+		{
+			field:   "complete",
+			rawBool: false,
+			resource: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "snapshot.kubevirt.io/v1beta1", "kind": "VirtualMachineRestore",
+				"metadata": map[string]interface{}{"name": "test"},
+				"status":   map[string]interface{}{"complete": false},
+			}},
+		},
+	}
+
+	for _, tc := range fields {
+		t.Run(tc.field, func(t *testing.T) {
+			node := GenericResourceBuilder(tc.resource).BuildNode()
+			stored := node.Properties[tc.field]
+
+			// Regression check 1: must NOT be stored as a raw bool.
+			// If this assertion fails it means the search API query
+			// "WHERE data->'field' ? 'true'" will return 0 results.
+			if _, isBool := stored.(bool); isBool {
+				t.Fatalf(
+					"REGRESSION: %s is stored as raw bool %v — the search API "+
+						"cannot query it. Must be stored as string %q instead.",
+					tc.field, tc.rawBool, fmt.Sprintf("%v", tc.rawBool))
+			}
+
+			// Regression check 2: must be the correct string value.
+			expected := fmt.Sprintf("%v", tc.rawBool)
+			if stored != expected {
+				t.Fatalf("%s: expected string %q, got %T %v", tc.field, expected, stored, stored)
+			}
+		})
+	}
 }

--- a/pkg/transforms/genericResource_test.go
+++ b/pkg/transforms/genericResource_test.go
@@ -3,7 +3,6 @@
 package transforms
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stolostron/search-collector/pkg/config"

--- a/pkg/transforms/genericResource_test.go
+++ b/pkg/transforms/genericResource_test.go
@@ -655,8 +655,10 @@ func Test_genericResourceFromConfigTemplateNoMatchLabel(t *testing.T) {
 }
 
 // TestBooleanFieldsStoredAsStrings_GenericConfig verifies that boolean fields
-// extracted via genericResourceConfig (using DataType: DataTypeString) are stored
-// as their string representations so the search API can query them correctly.
+// extracted via genericResourceConfig are stored as their string representations
+// so the search API can query them correctly. The API queries JSONB fields using
+// the '?' key-exists operator which only matches strings — a raw JSON boolean
+// is unreachable via "field:true" queries. See: https://issues.redhat.com/browse/ACM-30764
 func TestBooleanFieldsStoredAsStrings_GenericConfig(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -779,74 +781,3 @@ func TestBooleanFieldsStoredAsStrings_GenericConfig(t *testing.T) {
 	}
 }
 
-// TestBooleanFieldsNotStoredAsRawBool_RegressionPrevention is a regression test
-// that explicitly documents WHY booleans must be stored as strings.
-//
-// The search API queries JSONB fields using the '?' key-exists operator, which
-// only matches string keys inside a JSONB object. A raw JSON boolean (true/false)
-// is NOT a key and cannot be found by the '?' operator. Storing booleans as
-// strings ("true"/"false") makes them queryable as:
-//
-//   WHERE data->'allowVolumeExpansion' ? 'true'   -- works for string "true"
-//
-// If a value were stored as a raw boolean, that SQL would return 0 rows even
-// though the field is set. This test prevents that regression by asserting:
-// 1. The stored type is string, not bool.
-// 2. The stored value equals the expected string ("true" or "false").
-func TestBooleanFieldsNotStoredAsRawBool_RegressionPrevention(t *testing.T) {
-	fields := []struct {
-		resource *unstructured.Unstructured
-		field    string
-		rawBool  bool
-	}{
-		{
-			field:   "allowVolumeExpansion",
-			rawBool: true,
-			resource: &unstructured.Unstructured{Object: map[string]interface{}{
-				"apiVersion": "storage.k8s.io/v1", "kind": "StorageClass",
-				"metadata": map[string]interface{}{"name": "test"}, "allowVolumeExpansion": true,
-			}},
-		},
-		{
-			field:   "readyToUse",
-			rawBool: true,
-			resource: &unstructured.Unstructured{Object: map[string]interface{}{
-				"apiVersion": "snapshot.kubevirt.io/v1beta1", "kind": "VirtualMachineSnapshot",
-				"metadata": map[string]interface{}{"name": "test"},
-				"status":   map[string]interface{}{"readyToUse": true},
-			}},
-		},
-		{
-			field:   "complete",
-			rawBool: false,
-			resource: &unstructured.Unstructured{Object: map[string]interface{}{
-				"apiVersion": "snapshot.kubevirt.io/v1beta1", "kind": "VirtualMachineRestore",
-				"metadata": map[string]interface{}{"name": "test"},
-				"status":   map[string]interface{}{"complete": false},
-			}},
-		},
-	}
-
-	for _, tc := range fields {
-		t.Run(tc.field, func(t *testing.T) {
-			node := GenericResourceBuilder(tc.resource).BuildNode()
-			stored := node.Properties[tc.field]
-
-			// Regression check 1: must NOT be stored as a raw bool.
-			// If this assertion fails it means the search API query
-			// "WHERE data->'field' ? 'true'" will return 0 results.
-			if _, isBool := stored.(bool); isBool {
-				t.Fatalf(
-					"REGRESSION: %s is stored as raw bool %v — the search API "+
-						"cannot query it. Must be stored as string %q instead.",
-					tc.field, tc.rawBool, fmt.Sprintf("%v", tc.rawBool))
-			}
-
-			// Regression check 2: must be the correct string value.
-			expected := fmt.Sprintf("%v", tc.rawBool)
-			if stored != expected {
-				t.Fatalf("%s: expected string %q, got %T %v", tc.field, expected, stored, stored)
-			}
-		})
-	}
-}

--- a/pkg/transforms/kyverno.go
+++ b/pkg/transforms/kyverno.go
@@ -3,6 +3,7 @@
 package transforms
 
 import (
+	"strconv"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,8 +53,8 @@ func KyvernoPolicyResourceBuilder(p *unstructured.Unstructured) *KyvernoPolicyRe
 		}
 	}
 
-	node.Properties["background"] = background
-	node.Properties["admission"] = admission
+	node.Properties["background"] = strconv.FormatBool(background)
+	node.Properties["admission"] = strconv.FormatBool(admission)
 	node.Properties["severity"] = p.GetAnnotations()["policies.kyverno.io/severity"]
 
 	return &KyvernoPolicyResource{node: node}

--- a/pkg/transforms/kyverno_test.go
+++ b/pkg/transforms/kyverno_test.go
@@ -31,8 +31,8 @@ func TestTransformKyvernoPolicy(t *testing.T) {
 	node := rv.node
 
 	AssertEqual("validationFailureAction", node.Properties["validationFailureAction"], "Enforce", t)
-	AssertEqual("background", node.Properties["background"], true, t)
-	AssertEqual("admission", node.Properties["admission"], true, t)
+	AssertEqual("background", node.Properties["background"], "true", t)
+	AssertEqual("admission", node.Properties["admission"], "true", t)
 	AssertEqual("severity", node.Properties["severity"], "medium", t)
 
 	// Check the default value for spec.validationFailureAction
@@ -42,6 +42,58 @@ func TestTransformKyvernoPolicy(t *testing.T) {
 	node = rv.node
 	AssertEqual("validationFailureAction", node.Properties["validationFailureAction"], "Audit", t)
 }
+
+// TestBooleanFieldsStoredAsStrings_Kyverno verifies that background and admission
+// fields are stored as strings so the search API can query "background:true" correctly.
+func TestBooleanFieldsStoredAsStrings_Kyverno(t *testing.T) {
+	tests := []struct {
+		name               string
+		specBackground     *bool
+		specAdmission      *bool
+		expectedBackground string
+		expectedAdmission  string
+	}{
+		{"defaults (both true)", nil, nil, "true", "true"},
+		{"background=false, admission=false", boolPtr(false), boolPtr(false), "false", "false"},
+		{"background=true, admission=false", boolPtr(true), boolPtr(false), "true", "false"},
+		{"background=false, admission=true", boolPtr(false), boolPtr(true), "false", "true"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := map[string]interface{}{}
+			if tc.specBackground != nil {
+				spec["background"] = *tc.specBackground
+			}
+			if tc.specAdmission != nil {
+				spec["admission"] = *tc.specAdmission
+			}
+			p := unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "kyverno.io/v1",
+				"kind":       "Policy",
+				"metadata":   map[string]interface{}{"name": "test"},
+				"spec":       spec,
+			}}
+			node := KyvernoPolicyResourceBuilder(&p).node
+
+			bgVal, bgOk := node.Properties["background"].(string)
+			if !bgOk {
+				t.Fatalf("background should be a string, got %T: %v",
+					node.Properties["background"], node.Properties["background"])
+			}
+			adVal, adOk := node.Properties["admission"].(string)
+			if !adOk {
+				t.Fatalf("admission should be a string, got %T: %v",
+					node.Properties["admission"], node.Properties["admission"])
+			}
+			AssertEqual("background", bgVal, tc.expectedBackground, t)
+			AssertEqual("admission", adVal, tc.expectedAdmission, t)
+		})
+	}
+}
+
+// boolPtr is a helper to get a pointer to a bool literal.
+func boolPtr(b bool) *bool { return &b }
 
 func TestTransformKyvernoClusterPolicy(t *testing.T) {
 	p := unstructured.Unstructured{
@@ -66,8 +118,8 @@ func TestTransformKyvernoClusterPolicy(t *testing.T) {
 	node := rv.node
 
 	AssertEqual("validationFailureAction", node.Properties["validationFailureAction"], "Enforce", t)
-	AssertEqual("background", node.Properties["background"], false, t)
-	AssertEqual("admission", node.Properties["admission"], false, t)
+	AssertEqual("background", node.Properties["background"], "false", t)
+	AssertEqual("admission", node.Properties["admission"], "false", t)
 	AssertEqual("severity", node.Properties["severity"], "critical", t)
 }
 
@@ -325,64 +377,64 @@ func TestTransformKyvernoValidationAction(t *testing.T) {
 		testName           string
 		policy             *unstructured.Unstructured
 		expectedValidation string
-		expectedBackground bool
-		expectedAdmission  bool
+		expectedBackground string
+		expectedAdmission  string
 		expectedSeverity   string
 	}{
 		{
 			testName:           "Test ValidatingPolicy with Deny action",
 			policy:             validatingPolicy,
 			expectedValidation: "Deny",
-			expectedBackground: true,
-			expectedAdmission:  true,
+			expectedBackground: "true",
+			expectedAdmission:  "true",
 			expectedSeverity:   "medium",
 		},
 		{
 			testName:           "Test MutatingPolicy",
 			policy:             mutatingPolicy,
 			expectedValidation: "",
-			expectedBackground: true,
-			expectedAdmission:  true,
+			expectedBackground: "true",
+			expectedAdmission:  "true",
 			expectedSeverity:   "medium",
 		},
 		{
 			testName:           "Test ImageValidatingPolicy",
 			policy:             imageValidatingPolicy,
 			expectedValidation: "Audit/Deny",
-			expectedBackground: true,
-			expectedAdmission:  true,
+			expectedBackground: "true",
+			expectedAdmission:  "true",
 			expectedSeverity:   "high",
 		},
 		{
 			testName:           "Test GeneratingPolicy",
 			policy:             generatingPolicy,
 			expectedValidation: "",
-			expectedBackground: true,
-			expectedAdmission:  true,
+			expectedBackground: "true",
+			expectedAdmission:  "true",
 			expectedSeverity:   "low",
 		},
 		{
 			testName:           "Test ValidatingPolicy with evaluation disabled",
 			policy:             validatingPolicyDisabled,
 			expectedValidation: "Audit",
-			expectedBackground: false,
-			expectedAdmission:  false,
+			expectedBackground: "false",
+			expectedAdmission:  "false",
 			expectedSeverity:   "medium",
 		},
 		{
 			testName:           "Test ImageValidatingPolicy with evaluation disabled",
 			policy:             imageValidatingPolicyDisabled,
 			expectedValidation: "Audit/Deny",
-			expectedBackground: false,
-			expectedAdmission:  false,
+			expectedBackground: "false",
+			expectedAdmission:  "false",
 			expectedSeverity:   "high",
 		},
 		{
 			testName:           "Test NamespacedValidatingPolicy",
 			policy:             namespacedValidatingPolicy,
 			expectedValidation: "Deny",
-			expectedBackground: true,
-			expectedAdmission:  true,
+			expectedBackground: "true",
+			expectedAdmission:  "true",
 			expectedSeverity:   "medium",
 		},
 	}

--- a/pkg/transforms/policy.go
+++ b/pkg/transforms/policy.go
@@ -13,6 +13,7 @@ package transforms
 import (
 	"encoding/json"
 	"slices"
+	"strconv"
 	"strings"
 
 	policy "github.com/stolostron/governance-policy-propagator/api/v1"
@@ -37,7 +38,7 @@ func PolicyResourceBuilder(p *policy.Policy) *PolicyResource {
 	apiGroupVersion(p.TypeMeta, &node) // add kind, apigroup and version
 	// Extract the properties specific to this type
 	node.Properties["remediationAction"] = string(p.Spec.RemediationAction)
-	node.Properties["disabled"] = p.Spec.Disabled
+	node.Properties["disabled"] = strconv.FormatBool(p.Spec.Disabled)
 	node.Properties["numRules"] = len(p.Spec.PolicyTemplates)
 	// For the root policy (on hub, in non cluster ns), it doesn't have an overall status. it has status per cluster.
 	// On managed cluster, compliance is reported by status.compliant
@@ -83,7 +84,8 @@ func getPolicyCommonProperties(c *unstructured.Unstructured, node Node) Node {
 
 	node.Properties["remediationAction"], _, _ = unstructured.NestedString(c.Object, "spec", "remediationAction")
 
-	node.Properties["disabled"], _, _ = unstructured.NestedBool(c.Object, "spec", "disabled")
+	disabled, _, _ := unstructured.NestedBool(c.Object, "spec", "disabled")
+	node.Properties["disabled"] = strconv.FormatBool(disabled)
 
 	return node
 }

--- a/pkg/transforms/policy.go
+++ b/pkg/transforms/policy.go
@@ -131,8 +131,8 @@ func OperatorPolicyResourceBuilder(c *unstructured.Unstructured) *PolicyResource
 		}
 	}
 
-	node.Properties["deploymentAvailable"] = deploymentAvailable
-	node.Properties["upgradeAvailable"] = upgradeAvailable
+	node.Properties["deploymentAvailable"] = strconv.FormatBool(deploymentAvailable)
+	node.Properties["upgradeAvailable"] = strconv.FormatBool(upgradeAvailable)
 
 	return &PolicyResource{
 		node: node,

--- a/pkg/transforms/policy_test.go
+++ b/pkg/transforms/policy_test.go
@@ -71,8 +71,8 @@ func TestTransformOperatorPolicy(t *testing.T) {
 	AssertEqual("compliant", node.Properties["compliant"], "NonCompliant", t)
 	AssertEqual("remediationAction", node.Properties["remediationAction"], "inform", t)
 	AssertEqual("severity", node.Properties["severity"], "critical", t)
-	AssertEqual("deploymentAvailable", node.Properties["deploymentAvailable"], false, t)
-	AssertEqual("upgradeAvailable", node.Properties["upgradeAvailable"], true, t)
+	AssertEqual("deploymentAvailable", node.Properties["deploymentAvailable"], "false", t)
+	AssertEqual("upgradeAvailable", node.Properties["upgradeAvailable"], "true", t)
 	AssertEqual("disabled", node.Properties["disabled"], "false", t)
 	AssertEqual("_isExternal", node.Properties["_isExternal"], false, t)
 

--- a/pkg/transforms/policy_test.go
+++ b/pkg/transforms/policy_test.go
@@ -26,7 +26,7 @@ func TestTransformPolicy(t *testing.T) {
 
 	// Test only the fields that exist in policy - the common test will test the other bits
 	AssertEqual("remediationAction", node.Properties["remediationAction"], "enforce", t)
-	AssertEqual("disabled", node.Properties["disabled"], false, t)
+	AssertEqual("disabled", node.Properties["disabled"], "false", t)
 	AssertEqual("numRules", node.Properties["numRules"], 1, t)
 	assert.Len(t, node.Properties["annotation"], 3, "expected 3 annotations on the policy")
 }
@@ -47,7 +47,7 @@ func TestTransformConfigPolicy(t *testing.T) {
 	AssertEqual("compliant", node.Properties["compliant"], "NonCompliant", t)
 	AssertEqual("remediationAction", node.Properties["remediationAction"], "inform", t)
 	AssertEqual("severity", node.Properties["severity"], "low", t)
-	AssertEqual("disabled", node.Properties["disabled"], false, t)
+	AssertEqual("disabled", node.Properties["disabled"], "false", t)
 	AssertEqual("_isExternal", node.Properties["_isExternal"], true, t)
 	obj1 := `{"v":"v1","k":"Namespace","n":"default"}`
 	obj2 := `{"v":"v1","k":"Namespace","n":"nonexistent"}`
@@ -73,7 +73,7 @@ func TestTransformOperatorPolicy(t *testing.T) {
 	AssertEqual("severity", node.Properties["severity"], "critical", t)
 	AssertEqual("deploymentAvailable", node.Properties["deploymentAvailable"], false, t)
 	AssertEqual("upgradeAvailable", node.Properties["upgradeAvailable"], true, t)
-	AssertEqual("disabled", node.Properties["disabled"], false, t)
+	AssertEqual("disabled", node.Properties["disabled"], "false", t)
 	AssertEqual("_isExternal", node.Properties["_isExternal"], false, t)
 
 	objs := []relatedObject{{
@@ -114,8 +114,67 @@ func TestTransformCertPolicy(t *testing.T) {
 	// Test only the fields that exist in policy - the common test will test the other bits
 	AssertEqual("compliant", node.Properties["compliant"], "NonCompliant", t)
 	AssertEqual("severity", node.Properties["severity"], "low", t)
-	AssertEqual("disabled", node.Properties["disabled"], false, t)
+	AssertEqual("disabled", node.Properties["disabled"], "false", t)
 	AssertEqual("_isExternal", node.Properties["_isExternal"], true, t)
 	obj := `{"v":"v1","k":"Secret","ns":"default","n":"sample-secret"}`
 	AssertEqual("relObjs", node.GetMetadata("relObjs"), "["+obj+"]", t)
+}
+
+// TestBooleanFieldsStoredAsStrings_Policy verifies that boolean fields on Policy
+// resources are stored as their string representations ("true"/"false") so the
+// search API can query them correctly using JSONB string operators.
+func TestBooleanFieldsStoredAsStrings_Policy(t *testing.T) {
+	t.Run("disabled=false (default)", func(t *testing.T) {
+		p := policy.Policy{}
+		p.Spec.Disabled = false
+		node := PolicyResourceBuilder(&p).BuildNode()
+		val, ok := node.Properties["disabled"].(string)
+		if !ok {
+			t.Fatalf("disabled should be a string, got %T: %v", node.Properties["disabled"], node.Properties["disabled"])
+		}
+		AssertEqual("disabled", val, "false", t)
+	})
+
+	t.Run("disabled=true", func(t *testing.T) {
+		p := policy.Policy{}
+		p.Spec.Disabled = true
+		node := PolicyResourceBuilder(&p).BuildNode()
+		val, ok := node.Properties["disabled"].(string)
+		if !ok {
+			t.Fatalf("disabled should be a string, got %T: %v", node.Properties["disabled"], node.Properties["disabled"])
+		}
+		AssertEqual("disabled", val, "true", t)
+	})
+
+	t.Run("disabled via unstructured getPolicyCommonProperties false", func(t *testing.T) {
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{
+			"spec": map[string]interface{}{"disabled": false},
+		}}
+		node := getPolicyCommonProperties(obj, Node{Properties: map[string]interface{}{}})
+		val, ok := node.Properties["disabled"].(string)
+		if !ok {
+			t.Fatalf("disabled should be a string, got %T", node.Properties["disabled"])
+		}
+		AssertEqual("disabled (unstructured false)", val, "false", t)
+	})
+
+	t.Run("disabled via unstructured getPolicyCommonProperties true", func(t *testing.T) {
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{
+			"spec": map[string]interface{}{"disabled": true},
+		}}
+		node := getPolicyCommonProperties(obj, Node{Properties: map[string]interface{}{}})
+		val, ok := node.Properties["disabled"].(string)
+		if !ok {
+			t.Fatalf("disabled should be a string, got %T", node.Properties["disabled"])
+		}
+		AssertEqual("disabled (unstructured true)", val, "true", t)
+	})
+
+	t.Run("disabled missing from spec defaults to false string", func(t *testing.T) {
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{
+			"spec": map[string]interface{}{},
+		}}
+		node := getPolicyCommonProperties(obj, Node{Properties: map[string]interface{}{}})
+		AssertEqual("disabled (missing key)", node.Properties["disabled"], "false", t)
+	})
 }

--- a/pkg/transforms/subscription.go
+++ b/pkg/transforms/subscription.go
@@ -11,6 +11,7 @@ Copyright (c) 2020 Red Hat, Inc.
 package transforms
 
 import (
+	"strconv"
 	"strings"
 
 	app "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
@@ -47,10 +48,11 @@ func SubscriptionResourceBuilder(s *app.Subscription) *SubscriptionResource {
 		node.Properties["timeWindow"] = s.Spec.TimeWindow.WindowType
 	}
 	// Add localPlacement property
-	node.Properties["localPlacement"] = false
+	localPlacement := false
 	if s.Spec.Placement != nil && s.Spec.Placement.Local != nil {
-		node.Properties["localPlacement"] = *s.Spec.Placement.Local
+		localPlacement = *s.Spec.Placement.Local
 	}
+	node.Properties["localPlacement"] = strconv.FormatBool(localPlacement)
 	// Add hidden properties for app annotations
 	const appAnnotationPrefix string = "apps.open-cluster-management.io/"
 	const gitType = "git"

--- a/pkg/transforms/subscription_test.go
+++ b/pkg/transforms/subscription_test.go
@@ -46,5 +46,5 @@ func TestTransformSubscriptionWithLocalPlacement(t *testing.T) {
 	node := SubscriptionResourceBuilder(&s).BuildNode()
 
 	// Test optional fields that exist in subscription - the common test will test the other bits
-	AssertEqual("localPlacement", node.Properties["localPlacement"], true, t)
+	AssertEqual("localPlacement", node.Properties["localPlacement"], "true", t)
 }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ACM-30764

## Problem

Boolean fields like `allowVolumeExpansion: true` on StorageClass returned **zero search results** even when matching resources existed.

The search API queries JSONB fields as strings (`WHERE data->'field' ? 'true'`), but these fields were stored as JSON booleans — not strings — so the `?` operator never matched them.

**Affected fields (9 total):**
`disabled` (Policy), `suspend` (CronJob), `background`/`admission` (Kyverno), `allowVolumeExpansion` (StorageClass), `allowAutoConverge`/`allowPostCopy` (MigrationPolicy), `readyToUse` (VirtualMachineSnapshot), `complete` (VirtualMachineRestore)

## Fix

Two-part approach (aligns with closed PR #839 by @smcavey):

**1. Centralized (defensive):** In `applyDefaultTransformConfig` (`common.go`), any boolean value extracted via JSONPath is automatically converted to its string representation with `strconv.FormatBool()`. Future boolean fields are handled automatically.

**2. Targeted:** Explicit `strconv.FormatBool()` conversions in typed builders that hardcode boolean assignments: `policy.go` (`disabled`), `cronjob.go` (`suspend`), `kyverno.go` (`background`, `admission`).

## Tests

- Updated all existing assertions that expected `bool` values to expect `string` values
- Added 21 new tests covering every affected field × `true`/`false` combinations, nil pointer handling, and a dedicated **regression test** (`TestBooleanFieldsNotStoredAsRawBool_RegressionPrevention`) that explicitly fails if any field reverts to storing a raw boolean

## ⚠️ Breaking change / Errata note

Fields previously stored as JSON booleans (`true`/`false`) are now stored as strings (`"true"`/`"false"`). This is intentional — the API already treated them as strings for queries.

**Impact:** Any integration reading raw boolean values from the search index directly will now receive strings instead. Console queries and standard API usage are unaffected (actually improved — queries now return results).

This change is appropriate for the 5.0 major version boundary.

## E2E Test Results
Tested on ACM 5.0.0-83.
**Before fix:** `kind:StorageClass allowVolumeExpansion:true` returned 0 results. PostgreSQL stored the field as a JSON boolean so the API's string-based query couldn't match it.
**After fix:** 
- `jsonb_typeof(data->'allowVolumeExpansion')` → `string` ✅  
- `kind:StorageClass allowVolumeExpansion:true` → `count: 2` ✅  
- `kind:Policy disabled:true` → `count: 1` ✅  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Boolean-type resource properties are now consistently stored as string values ("true"/"false") across multiple resources (suspend, policy flags, placement, Kyverno settings, etc.), improving serialization consistency.

* **Tests**
  * Added and updated unit tests to assert boolean fields are serialized as strings and to prevent regressions across affected resource transforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->