### PR TITLE
ACM-32738 - configurable collection - additionalPrinterColumns

### DIFF
--- a/pkg/informer/runInformers.go
+++ b/pkg/informer/runInformers.go
@@ -253,6 +253,11 @@ func (g *gvrToPrinterColumns) set(crd *unstructured.Unstructured) error {
 				continue
 			}
 
+			var priority int
+			if p, ok := columnTyped["priority"].(int64); ok {
+				priority = int(p)
+			}
+
 			// The additionalPrinterColumns always have a JSON path without curly braces enclosing it, but the
 			// ExtractProperty.JSONPath field expects them.
 			jsonPath = fmt.Sprintf("{%s}", jsonPath)
@@ -263,7 +268,7 @@ func (g *gvrToPrinterColumns) set(crd *unstructured.Unstructured) error {
 				continue
 			}
 
-			printerColumns = append(printerColumns, tr.ExtractProperty{Name: camelCaseName, JSONPath: jsonPath})
+			printerColumns = append(printerColumns, tr.ExtractProperty{Name: camelCaseName, JSONPath: jsonPath, Priority: &priority})
 		}
 
 		break

--- a/pkg/informer/runInformers_test.go
+++ b/pkg/informer/runInformers_test.go
@@ -278,7 +278,53 @@ func Test_gvrToPrinterColumns(t *testing.T) {
 	// At first, the mapping should be empty.
 	assert.Nil(t, gvrToColumns.get(gvr))
 
-	crd := unstructured.Unstructured{
+	crd := newSimpleCRDWithAdditionalPrinterColumns()
+
+	// Cache the mapping for the CRD
+	assert.Nil(t, gvrToColumns.set(&crd))
+
+	zerVal := 0
+	expected := []tr.ExtractProperty{
+		{Name: "complianceState", JSONPath: "{.status.compliant}", Priority: &zerVal},
+	}
+
+	// Verify the correct GVR was parsed and the mapping was stored
+	assert.Equal(t, expected, gvrToColumns.get(gvr))
+
+	// Verify the mapping can be unset
+	assert.Nil(t, gvrToColumns.unset(&crd))
+	assert.Nil(t, gvrToColumns.get(gvr))
+}
+
+func Test_gvrToPrinterColumnsWithPriority(t *testing.T) {
+	gvrToColumns := gvrToPrinterColumns{mapping: map[schema.GroupVersionResource][]tr.ExtractProperty{}}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "policy.open-cluster-management.io",
+		Version:  "v1",
+		Resource: "fakes",
+	}
+
+	crd := newSimpleCRDWithAdditionalPrinterColumns()
+
+	// Set a non-zero priority on the printer column.
+	versions := crd.Object["spec"].(map[string]interface{})["versions"].([]interface{})
+	storageVersion := versions[1].(map[string]interface{})
+	columns := storageVersion["additionalPrinterColumns"].([]interface{})
+	columns[0].(map[string]interface{})["priority"] = int64(1)
+
+	assert.Nil(t, gvrToColumns.set(&crd))
+
+	priority := 1
+	expected := []tr.ExtractProperty{
+		{Name: "complianceState", JSONPath: "{.status.compliant}", Priority: &priority},
+	}
+
+	assert.Equal(t, expected, gvrToColumns.get(gvr))
+}
+
+func newSimpleCRDWithAdditionalPrinterColumns() unstructured.Unstructured {
+	return unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "apiextensions.k8s.io/v1",
 			"kind":       "CustomResourceDefinition",
@@ -314,18 +360,4 @@ func Test_gvrToPrinterColumns(t *testing.T) {
 			},
 		},
 	}
-
-	// Cache the mapping for the CRD
-	assert.Nil(t, gvrToColumns.set(&crd))
-
-	expected := []tr.ExtractProperty{
-		{Name: "complianceState", JSONPath: "{.status.compliant}"},
-	}
-
-	// Verify the correct GVR was parsed and the mapping was stored
-	assert.Equal(t, expected, gvrToColumns.get(gvr))
-
-	// Verify the mapping can be unset
-	assert.Nil(t, gvrToColumns.unset(&crd))
-	assert.Nil(t, gvrToColumns.get(gvr))
 }

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -706,10 +706,11 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 			continue
 		}
 
-		// Skip additionalPrinterColumns when not configured or below threshold
+		// Skip additionalPrinterColumns when not configured or above threshold.
+		// A threshold of N means collect columns with priority 0 through N.
 		if prop.Priority != nil {
 			if transformConfig.additionalPrinterColumnsPriority == nil ||
-				*prop.Priority < *transformConfig.additionalPrinterColumnsPriority {
+				*prop.Priority > *transformConfig.additionalPrinterColumnsPriority {
 				continue
 			}
 		}

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -666,12 +666,20 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 		}
 	}
 
-	// Currently, only pull in the additionalPrinterColumns listed in the CRD if it's a Gatekeeper
-	// constraint or globally enabled.
-	if !found && (config.Cfg.CollectCRDPrinterColumns || group == "constraints.gatekeeper.sh") {
-		transformConfig = ResourceConfig{properties: additionalColumns}
-	} else if !found {
-		return node
+	// Pull in additionalPrinterColumns when globally enabled, gatekeeper constraint,
+	// or when a wildcard config has only additionalPrinterColumnsPriority set.
+	if !found {
+		useColumns := config.Cfg.CollectCRDPrinterColumns || group == "constraints.gatekeeper.sh" ||
+			(wildcardFound && wildcardConfig.additionalPrinterColumnsPriority != nil)
+		if useColumns {
+			transformConfig = ResourceConfig{properties: additionalColumns}
+			// Inherit the priority threshold from the wildcard config.
+			if wildcardFound && wildcardConfig.additionalPrinterColumnsPriority != nil {
+				transformConfig.additionalPrinterColumnsPriority = wildcardConfig.additionalPrinterColumnsPriority
+			}
+		} else {
+			return node
+		}
 	}
 
 	for _, prop := range transformConfig.properties {
@@ -696,6 +704,14 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 		// Skip additionalPrinterColumns that should be ignored.
 		if !found && defaultTransformIgnoredFields[prop.Name] {
 			continue
+		}
+
+		// Skip additionalPrinterColumns when not configured or below threshold
+		if prop.Priority != nil {
+			if transformConfig.additionalPrinterColumnsPriority == nil ||
+				*prop.Priority < *transformConfig.additionalPrinterColumnsPriority {
+				continue
+			}
 		}
 
 		// Normalize the jsonPath before parsing — accept both "{.spec.field}" and

--- a/pkg/transforms/common_test.go
+++ b/pkg/transforms/common_test.go
@@ -295,6 +295,165 @@ func Test_genericResourceFromConfigMapNoLabelsToMatchMatchLabel(t *testing.T) {
 	assert.Equal(t, 5, len(node.Properties))
 }
 
+func intPtr(i int) *int { return &i }
+
+func TestAdditionalPrinterColumnsPriority_NotConfigured_Skipped(t *testing.T) {
+	// When ResourceConfig.additionalPrinterColumnsPriority is nil, printer columns should be skipped.
+	zeroPrio := 0
+	origConfig := mergedTransformConfig
+	mergedTransformConfig = map[string]ResourceConfig{
+		"Fake.test.io": {
+			properties: []ExtractProperty{
+				{Name: "status", JSONPath: "{.status.phase}", Priority: &zeroPrio},
+			},
+		},
+	}
+	defer func() { mergedTransformConfig = origConfig }()
+
+	r := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "test.io/v1",
+			"kind":       "Fake",
+			"metadata":   map[string]interface{}{"name": "test", "uid": "uid-1", "creationTimestamp": "2024-01-01T00:00:00Z"},
+			"status":     map[string]interface{}{"phase": "Running"},
+		},
+	}
+
+	node := GenericResourceBuilder(&r).BuildNode()
+	assert.Nil(t, node.Properties["status"], "Printer column should be skipped when priority threshold is not configured")
+}
+
+func TestAdditionalPrinterColumnsPriority_ThresholdZero_Collected(t *testing.T) {
+	// When ResourceConfig.additionalPrinterColumnsPriority is 0, priority-0 columns should be collected.
+	zeroPrio := 0
+	origConfig := mergedTransformConfig
+	mergedTransformConfig = map[string]ResourceConfig{
+		"Fake.test.io": {
+			properties: []ExtractProperty{
+				{Name: "status", JSONPath: "{.status.phase}", Priority: &zeroPrio},
+			},
+			additionalPrinterColumnsPriority: intPtr(0),
+		},
+	}
+	defer func() { mergedTransformConfig = origConfig }()
+
+	r := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "test.io/v1",
+			"kind":       "Fake",
+			"metadata":   map[string]interface{}{"name": "test", "uid": "uid-1", "creationTimestamp": "2024-01-01T00:00:00Z"},
+			"status":     map[string]interface{}{"phase": "Running"},
+		},
+	}
+
+	node := GenericResourceBuilder(&r).BuildNode()
+	assert.Equal(t, "Running", node.Properties["status"], "Priority-0 column should be collected when threshold is 0")
+}
+
+func TestAdditionalPrinterColumnsPriority_ThresholdOne_FiltersByPriority(t *testing.T) {
+	// When ResourceConfig.additionalPrinterColumnsPriority is 1, priority-0 columns should be skipped and priority-1 columns should be collected.
+	zeroPrio := 0
+	onePrio := 1
+	origConfig := mergedTransformConfig
+	mergedTransformConfig = map[string]ResourceConfig{
+		"Fake.test.io": {
+			properties: []ExtractProperty{
+				{Name: "lowPriority", JSONPath: "{.status.phase}", Priority: &zeroPrio},
+				{Name: "highPriority", JSONPath: "{.status.ready}", Priority: &onePrio},
+			},
+			additionalPrinterColumnsPriority: intPtr(1),
+		},
+	}
+	defer func() { mergedTransformConfig = origConfig }()
+
+	r := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "test.io/v1",
+			"kind":       "Fake",
+			"metadata":   map[string]interface{}{"name": "test", "uid": "uid-1", "creationTimestamp": "2024-01-01T00:00:00Z"},
+			"status":     map[string]interface{}{"phase": "Running", "ready": "True"},
+		},
+	}
+
+	node := GenericResourceBuilder(&r).BuildNode()
+	assert.Nil(t, node.Properties["lowPriority"], "Priority-0 column should be skipped when threshold is 1")
+	assert.Equal(t, "True", node.Properties["highPriority"], "Priority-1 column should be collected when threshold is 1")
+}
+
+func TestAdditionalPrinterColumns_WildcardOnly_CollectedViaAdditionalColumns(t *testing.T) {
+	// When there's no specific ResourceConfig for the resource but a wildcard config
+	// has additionalPrinterColumnsPriority set, printer columns passed as additionalColumns
+	// should be collected.
+	zeroPrio := 0
+	origConfig := mergedTransformConfig
+	mergedTransformConfig = map[string]ResourceConfig{
+		"*.test.io": {
+			additionalPrinterColumnsPriority: intPtr(0),
+		},
+	}
+	defer func() { mergedTransformConfig = origConfig }()
+
+	r := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "test.io/v1",
+			"kind":       "Fake",
+			"metadata":   map[string]interface{}{"name": "test", "uid": "uid-1", "creationTimestamp": "2024-01-01T00:00:00Z"},
+			"status":     map[string]interface{}{"phase": "Running"},
+		},
+	}
+
+	additionalColumns := []ExtractProperty{
+		{Name: "status", JSONPath: "{.status.phase}", Priority: &zeroPrio},
+	}
+
+	node := GenericResourceBuilder(&r, additionalColumns...).BuildNode()
+	// printer column field collected
+	assert.Equal(t, "Running", node.Properties["status"], "Printer column should be collected via wildcard config")
+	// default fields still collected
+	assert.Equal(t, "Fake", node.Properties["kind"], "Default property 'kind' should be collected")
+	assert.Equal(t, "test", node.Properties["name"], "Default property 'name' should be collected")
+	assert.Equal(t, "test.io", node.Properties["apigroup"], "Default property 'apigroup' should be collected")
+	assert.Equal(t, "v1", node.Properties["apiversion"], "Default property 'apiversion' should be collected")
+}
+
+func TestAdditionalPrinterColumns_SpecificConfig_BothPropertiesAndPrinterColumns(t *testing.T) {
+	// When a specific ResourceConfig exists with both regular properties and printer column
+	// properties, both should be collected.
+	zeroPrio := 0
+	origConfig := mergedTransformConfig
+	mergedTransformConfig = map[string]ResourceConfig{
+		"Fake.test.io": {
+			properties: []ExtractProperty{
+				{Name: "version", JSONPath: "{.spec.version}"},
+				{Name: "status", JSONPath: "{.status.phase}", Priority: &zeroPrio},
+			},
+			additionalPrinterColumnsPriority: intPtr(0),
+		},
+	}
+	defer func() { mergedTransformConfig = origConfig }()
+
+	r := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "test.io/v1",
+			"kind":       "Fake",
+			"metadata":   map[string]interface{}{"name": "test", "uid": "uid-1", "creationTimestamp": "2024-01-01T00:00:00Z"},
+			"spec":       map[string]interface{}{"version": "1.2.3"},
+			"status":     map[string]interface{}{"phase": "Running"},
+		},
+	}
+
+	node := GenericResourceBuilder(&r).BuildNode()
+	// configured field collected
+	assert.Equal(t, "1.2.3", node.Properties["version"], "Regular property should be collected")
+	// printer column field also collected
+	assert.Equal(t, "Running", node.Properties["status"], "Printer column property should also be collected")
+	// default fields still collected
+	assert.Equal(t, "Fake", node.Properties["kind"], "Default property 'kind' should be collected")
+	assert.Equal(t, "test", node.Properties["name"], "Default property 'name' should be collected")
+	assert.Equal(t, "test.io", node.Properties["apigroup"], "Default property 'apigroup' should be collected")
+	assert.Equal(t, "v1", node.Properties["apiversion"], "Default property 'apiversion' should be collected")
+}
+
 func TestConvertToString(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/transforms/common_test.go
+++ b/pkg/transforms/common_test.go
@@ -351,15 +351,17 @@ func TestAdditionalPrinterColumnsPriority_ThresholdZero_Collected(t *testing.T) 
 }
 
 func TestAdditionalPrinterColumnsPriority_ThresholdOne_FiltersByPriority(t *testing.T) {
-	// When ResourceConfig.additionalPrinterColumnsPriority is 1, priority-0 columns should be skipped and priority-1 columns should be collected.
+	// When ResourceConfig.additionalPrinterColumnsPriority is 1, priority 0 and 1 should be collected, priority 2 should be skipped.
 	zeroPrio := 0
 	onePrio := 1
+	twoPrio := 2
 	origConfig := mergedTransformConfig
 	mergedTransformConfig = map[string]ResourceConfig{
 		"Fake.test.io": {
 			properties: []ExtractProperty{
-				{Name: "lowPriority", JSONPath: "{.status.phase}", Priority: &zeroPrio},
-				{Name: "highPriority", JSONPath: "{.status.ready}", Priority: &onePrio},
+				{Name: "important", JSONPath: "{.status.phase}", Priority: &zeroPrio},
+				{Name: "medium", JSONPath: "{.status.ready}", Priority: &onePrio},
+				{Name: "extra", JSONPath: "{.status.message}", Priority: &twoPrio},
 			},
 			additionalPrinterColumnsPriority: intPtr(1),
 		},
@@ -371,13 +373,14 @@ func TestAdditionalPrinterColumnsPriority_ThresholdOne_FiltersByPriority(t *test
 			"apiVersion": "test.io/v1",
 			"kind":       "Fake",
 			"metadata":   map[string]interface{}{"name": "test", "uid": "uid-1", "creationTimestamp": "2024-01-01T00:00:00Z"},
-			"status":     map[string]interface{}{"phase": "Running", "ready": "True"},
+			"status":     map[string]interface{}{"phase": "Running", "ready": "True", "message": "All good"},
 		},
 	}
 
 	node := GenericResourceBuilder(&r).BuildNode()
-	assert.Nil(t, node.Properties["lowPriority"], "Priority-0 column should be skipped when threshold is 1")
-	assert.Equal(t, "True", node.Properties["highPriority"], "Priority-1 column should be collected when threshold is 1")
+	assert.Equal(t, "Running", node.Properties["important"], "Priority-0 column should be collected when threshold is 1")
+	assert.Equal(t, "True", node.Properties["medium"], "Priority-1 column should be collected when threshold is 1")
+	assert.Nil(t, node.Properties["extra"], "Priority-2 column should be skipped when threshold is 1")
 }
 
 func TestAdditionalPrinterColumns_WildcardOnly_CollectedViaAdditionalColumns(t *testing.T) {

--- a/pkg/transforms/configurableCollection.go
+++ b/pkg/transforms/configurableCollection.go
@@ -112,7 +112,7 @@ func loadAndMergeConfigurableCollectionWithClient(dynamicClient dynamic.Interfac
 		hasCollectAnnotations := rule.CollectAnnotations != nil && *rule.CollectAnnotations
 		hasCollectPrinterColumns := rule.CollectAdditionalPrinterColumnsPriority != nil
 
-		// Only process rules that have fields specified
+		// Only process rules that have actionable configuration
 		if !hasFields && !hasCollectConditions && !hasCollectPrinterColumns && !hasCollectAnnotations {
 			msg := "Rule skipped: include action requires at least one field, collectConditions, collectAnnotations, or collectAdditionalPrinterColumnsPriority"
 			klog.Warning("Skipping collection rule. Include action without fields, collectConditions, collectAnnotations, or collectAdditionalPrinterColumnsPriority specified.")

--- a/pkg/transforms/configurableCollection.go
+++ b/pkg/transforms/configurableCollection.go
@@ -110,11 +110,12 @@ func loadAndMergeConfigurableCollectionWithClient(dynamicClient dynamic.Interfac
 		hasFields := len(rule.Fields) > 0
 		hasCollectConditions := rule.CollectConditions != nil && *rule.CollectConditions
 		hasCollectAnnotations := rule.CollectAnnotations != nil && *rule.CollectAnnotations
+		hasCollectPrinterColumns := rule.CollectAdditionalPrinterColumnsPriority != nil
 
-		// Only process rules that have actionable configuration
-		if !hasFields && !hasCollectConditions && !hasCollectAnnotations {
-			msg := "Rule skipped: include action requires at least one field, collectConditions, or collectAnnotations"
-			klog.Warning("Skipping collection rule. Include action without fields, collectConditions, or collectAnnotations specified.")
+		// Only process rules that have fields specified
+		if !hasFields && !hasCollectConditions && !hasCollectPrinterColumns && !hasCollectAnnotations {
+			msg := "Rule skipped: include action requires at least one field, collectConditions, collectAnnotations, or collectAdditionalPrinterColumnsPriority"
+			klog.Warning("Skipping collection rule. Include action without fields, collectConditions, collectAnnotations, or collectAdditionalPrinterColumnsPriority specified.")
 			warnings = append(warnings, msg)
 			continue
 		}
@@ -125,17 +126,20 @@ func loadAndMergeConfigurableCollectionWithClient(dynamicClient dynamic.Interfac
 		// Process collectConditions
 		if hasCollectConditions {
 			mergeCollectConditions(apiGroups, kinds)
-			if !hasFields && !hasCollectAnnotations {
-				continue
-			}
 		}
 
 		// Process collectAnnotations
 		if hasCollectAnnotations {
 			mergeCollectAnnotations(apiGroups, kinds)
-			if !hasFields {
-				continue
-			}
+		}
+
+		// Process collectAdditionalPrinterColumnsPriority
+		if hasCollectPrinterColumns {
+			mergeCollectPrinterColumns(apiGroups, kinds, *rule.CollectAdditionalPrinterColumnsPriority)
+		}
+
+		if !hasFields {
+			continue
 		}
 
 		// Filter out wildcard kinds before fields processing — fields require a specific kind.
@@ -392,6 +396,33 @@ func mergeCollectAnnotations(apiGroups, kinds []string) {
 	}
 }
 
+// mergeCollectPrinterColumns sets the additionalPrinterColumns priority threshold for the given apiGroups and kinds.
+// When kind is "*", a wildcard entry (e.g., "*" or "*.apps") is stored in mergedTransformConfig,
+// enabling printer column collection for all resources in that apiGroup at runtime.
+// For specific kinds, the priority is set for each kind+apiGroup combination.
+func mergeCollectPrinterColumns(apiGroups, kinds []string, priority int) {
+	for _, apiGroup := range apiGroups {
+		for _, kind := range kinds {
+			if kind == "" {
+				continue
+			}
+			resourceKey := kind
+			if apiGroup != "" {
+				resourceKey = kind + "." + apiGroup
+			}
+			resourceConfig, exists := mergedTransformConfig[resourceKey]
+			if !exists {
+				resourceConfig = ResourceConfig{
+					properties: []ExtractProperty{},
+				}
+			}
+			resourceConfig.additionalPrinterColumnsPriority = &priority
+			mergedTransformConfig[resourceKey] = resourceConfig
+			klog.V(2).Infof("Set additionalPrinterColumns priority to %d for resource %s", priority, resourceKey)
+		}
+	}
+}
+
 // dataTypeFromCRD converts v1alpha1.DataType to internal DataType
 func dataTypeFromCRD(crdType v1alpha1.DataType) DataType {
 	switch crdType {
@@ -422,11 +453,18 @@ func deepCopyTransformConfig(src map[string]ResourceConfig) map[string]ResourceC
 		copiedEdges := make([]ExtractEdge, len(config.edges))
 		copy(copiedEdges, config.edges)
 
+		var copiedPriority *int
+		if config.additionalPrinterColumnsPriority != nil {
+			p := *config.additionalPrinterColumnsPriority
+			copiedPriority = &p
+		}
+
 		dst[key] = ResourceConfig{
-			properties:         copiedProperties,
-			edges:              copiedEdges,
-			extractAnnotations: config.extractAnnotations,
-			extractConditions:  config.extractConditions,
+			properties:                       copiedProperties,
+			edges:                            copiedEdges,
+			extractAnnotations:               config.extractAnnotations,
+			extractConditions:                config.extractConditions,
+			additionalPrinterColumnsPriority: copiedPriority,
 		}
 	}
 	return dst

--- a/pkg/transforms/configurableCollection.go
+++ b/pkg/transforms/configurableCollection.go
@@ -416,9 +416,13 @@ func mergeCollectPrinterColumns(apiGroups, kinds []string, priority int) {
 					properties: []ExtractProperty{},
 				}
 			}
-			resourceConfig.additionalPrinterColumnsPriority = &priority
+			// Take the max priority — higher values are more permissive (collect more columns).
+			// This prevents a later rule from accidentally narrowing an earlier rule's threshold.
+			if resourceConfig.additionalPrinterColumnsPriority == nil || priority > *resourceConfig.additionalPrinterColumnsPriority {
+				resourceConfig.additionalPrinterColumnsPriority = &priority
+			}
 			mergedTransformConfig[resourceKey] = resourceConfig
-			klog.V(2).Infof("Set additionalPrinterColumns priority to %d for resource %s", priority, resourceKey)
+			klog.V(2).Infof("Set additionalPrinterColumns priority to %d for resource %s", *resourceConfig.additionalPrinterColumnsPriority, resourceKey)
 		}
 	}
 }

--- a/pkg/transforms/configurableCollection_test.go
+++ b/pkg/transforms/configurableCollection_test.go
@@ -2250,6 +2250,161 @@ func TestStatusCondition_WarningTruncation(t *testing.T) {
 	}
 }
 
+func TestLoadAndMergeConfigurableCollection_CollectPrinterColumnsSpecificKind(t *testing.T) {
+	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
+	originalNamespace := config.Cfg.PodNamespace
+	defer func() {
+		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
+		config.Cfg.PodNamespace = originalNamespace
+		mergedTransformConfig = nil
+	}()
+
+	config.Cfg.FeatureConfigurableCollection = true
+	config.Cfg.PodNamespace = "test-namespace"
+
+	collectionConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					map[string]interface{}{
+						"action": "include",
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"monitoring.coreos.com"},
+							"kinds":     []interface{}{"Alertmanager"},
+						},
+						"collectAdditionalPrinterColumnsPriority": int64(5),
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewSimpleDynamicClient(scheme, collectionConfig)
+
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	rc, exists := mergedTransformConfig["Alertmanager.monitoring.coreos.com"]
+	assert.True(t, exists, "Alertmanager.monitoring.coreos.com config should exist")
+	assert.NotNil(t, rc.additionalPrinterColumnsPriority, "additionalPrinterColumnsPriority should be set")
+	assert.Equal(t, 5, *rc.additionalPrinterColumnsPriority, "priority threshold should be 5")
+}
+
+func TestLoadAndMergeConfigurableCollection_CollectPrinterColumnsWildcardKind(t *testing.T) {
+	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
+	originalNamespace := config.Cfg.PodNamespace
+	defer func() {
+		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
+		config.Cfg.PodNamespace = originalNamespace
+		mergedTransformConfig = nil
+	}()
+
+	config.Cfg.FeatureConfigurableCollection = true
+	config.Cfg.PodNamespace = "test-namespace"
+
+	collectionConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					map[string]interface{}{
+						"action": "include",
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"monitoring.coreos.com"},
+							"kinds":     []interface{}{"*"},
+						},
+						"collectAdditionalPrinterColumnsPriority": int64(0),
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewSimpleDynamicClient(scheme, collectionConfig)
+
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	rc, exists := mergedTransformConfig["*.monitoring.coreos.com"]
+	assert.True(t, exists, "*.monitoring.coreos.com wildcard config should exist")
+	assert.NotNil(t, rc.additionalPrinterColumnsPriority, "additionalPrinterColumnsPriority should be set")
+	assert.Equal(t, 0, *rc.additionalPrinterColumnsPriority, "priority threshold should be 0")
+}
+
+func TestLoadAndMergeConfigurableCollection_CollectPrinterColumnsWithFieldsAndConditions(t *testing.T) {
+	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
+	originalNamespace := config.Cfg.PodNamespace
+	defer func() {
+		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
+		config.Cfg.PodNamespace = originalNamespace
+		mergedTransformConfig = nil
+	}()
+
+	config.Cfg.FeatureConfigurableCollection = true
+	config.Cfg.PodNamespace = "test-namespace"
+
+	collectionConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					map[string]interface{}{
+						"action":            "include",
+						"collectConditions": true,
+						"collectAdditionalPrinterColumnsPriority": int64(1),
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"kubevirt.io"},
+							"kinds":     []interface{}{"VirtualMachine"},
+						},
+						"fields": []interface{}{
+							map[string]interface{}{
+								"name":     "running",
+								"jsonPath": "{.spec.running}",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewSimpleDynamicClient(scheme, collectionConfig)
+
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	rc, exists := mergedTransformConfig["VirtualMachine.kubevirt.io"]
+	assert.True(t, exists, "VirtualMachine.kubevirt.io config should exist")
+	assert.True(t, rc.extractConditions, "extractConditions should be true")
+	assert.NotNil(t, rc.additionalPrinterColumnsPriority, "additionalPrinterColumnsPriority should be set")
+	assert.Equal(t, 1, *rc.additionalPrinterColumnsPriority, "priority threshold should be 1")
+	// The custom field should be merged into the config (may also contain default properties).
+	foundRunning := false
+	for _, p := range rc.properties {
+		if p.Name == "running" {
+			foundRunning = true
+			break
+		}
+	}
+	assert.True(t, foundRunning, "custom field 'running' should be present in properties")
+}
+
 // TestNormalizeJSONPath verifies that the collector accepts jsonPath values both
 // with and without curly-brace wrapping, normalizing them automatically so users
 // don't need to know the k8s jsonpath library convention.

--- a/pkg/transforms/configurableCollection_test.go
+++ b/pkg/transforms/configurableCollection_test.go
@@ -2405,6 +2405,65 @@ func TestLoadAndMergeConfigurableCollection_CollectPrinterColumnsWithFieldsAndCo
 	assert.True(t, foundRunning, "custom field 'running' should be present in properties")
 }
 
+func TestLoadAndMergeConfigurableCollection_CollectPrinterColumnsPriorityMaxWins(t *testing.T) {
+	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
+	originalNamespace := config.Cfg.PodNamespace
+	defer func() {
+		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
+		config.Cfg.PodNamespace = originalNamespace
+		mergedTransformConfig = nil
+	}()
+
+	config.Cfg.FeatureConfigurableCollection = true
+	config.Cfg.PodNamespace = "test-namespace"
+
+	// Two rules target the same resource with different priorities.
+	// The higher value (more permissive) should win regardless of order.
+	collectionConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					// Integration team rule: priority 10
+					map[string]interface{}{
+						"action": "include",
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"monitoring.coreos.com"},
+							"kinds":     []interface{}{"Alertmanager"},
+						},
+						"collectAdditionalPrinterColumnsPriority": int64(10),
+					},
+					// User rule: priority 0 (should not narrow the team's threshold)
+					map[string]interface{}{
+						"action": "include",
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"monitoring.coreos.com"},
+							"kinds":     []interface{}{"Alertmanager"},
+						},
+						"collectAdditionalPrinterColumnsPriority": int64(0),
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewSimpleDynamicClient(scheme, collectionConfig)
+
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	rc, exists := mergedTransformConfig["Alertmanager.monitoring.coreos.com"]
+	assert.True(t, exists, "Alertmanager.monitoring.coreos.com config should exist")
+	assert.NotNil(t, rc.additionalPrinterColumnsPriority, "additionalPrinterColumnsPriority should be set")
+	assert.Equal(t, 10, *rc.additionalPrinterColumnsPriority,
+		"Max priority should win — user's priority 0 should not narrow team's priority 10")
+}
+
 // TestNormalizeJSONPath verifies that the collector accepts jsonPath values both
 // with and without curly-brace wrapping, normalizing them automatically so users
 // don't need to know the k8s jsonpath library convention.

--- a/pkg/transforms/configurableCollection_test.go
+++ b/pkg/transforms/configurableCollection_test.go
@@ -2464,6 +2464,65 @@ func TestLoadAndMergeConfigurableCollection_CollectPrinterColumnsPriorityMaxWins
 		"Max priority should win — user's priority 0 should not narrow team's priority 10")
 }
 
+func TestLoadAndMergeConfigurableCollection_CollectPrinterColumnsPriorityMaxWinsReverseProcessingOrder(t *testing.T) {
+	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
+	originalNamespace := config.Cfg.PodNamespace
+	defer func() {
+		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
+		config.Cfg.PodNamespace = originalNamespace
+		mergedTransformConfig = nil
+	}()
+
+	config.Cfg.FeatureConfigurableCollection = true
+	config.Cfg.PodNamespace = "test-namespace"
+
+	// Two rules target the same resource with different priorities.
+	// The higher value (more permissive) should win regardless of order.
+	collectionConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					// Integration team rule: priority 0
+					map[string]interface{}{
+						"action": "include",
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"monitoring.coreos.com"},
+							"kinds":     []interface{}{"Alertmanager"},
+						},
+						"collectAdditionalPrinterColumnsPriority": int64(0),
+					},
+					// User rule: priority 10 (should not narrow the team's threshold)
+					map[string]interface{}{
+						"action": "include",
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"monitoring.coreos.com"},
+							"kinds":     []interface{}{"Alertmanager"},
+						},
+						"collectAdditionalPrinterColumnsPriority": int64(10),
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewSimpleDynamicClient(scheme, collectionConfig)
+
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	rc, exists := mergedTransformConfig["Alertmanager.monitoring.coreos.com"]
+	assert.True(t, exists, "Alertmanager.monitoring.coreos.com config should exist")
+	assert.NotNil(t, rc.additionalPrinterColumnsPriority, "additionalPrinterColumnsPriority should be set")
+	assert.Equal(t, 10, *rc.additionalPrinterColumnsPriority,
+		"Max priority should win — team's priority 0 should not narrow user's priority 10")
+}
+
 // TestNormalizeJSONPath verifies that the collector accepts jsonPath values both
 // with and without curly-brace wrapping, normalizing them automatically so users
 // don't need to know the k8s jsonpath library convention.

--- a/pkg/transforms/configurableCollection_test.go
+++ b/pkg/transforms/configurableCollection_test.go
@@ -2523,6 +2523,112 @@ func TestLoadAndMergeConfigurableCollection_CollectPrinterColumnsPriorityMaxWins
 		"Max priority should win — team's priority 0 should not narrow user's priority 10")
 }
 
+func TestLoadAndMergeConfigurableCollection_CollectPrinterColumnsDisabled(t *testing.T) {
+	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
+	originalNamespace := config.Cfg.PodNamespace
+	defer func() {
+		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
+		config.Cfg.PodNamespace = originalNamespace
+		mergedTransformConfig = nil
+	}()
+
+	config.Cfg.FeatureConfigurableCollection = true
+	config.Cfg.PodNamespace = "test-namespace"
+
+	// Priority -1 should disable additionalPrinterColumns collection.
+	collectionConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					map[string]interface{}{
+						"action": "include",
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"monitoring.coreos.com"},
+							"kinds":     []interface{}{"Alertmanager"},
+						},
+						"collectAdditionalPrinterColumnsPriority": int64(-1),
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewSimpleDynamicClient(scheme, collectionConfig)
+
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	rc, exists := mergedTransformConfig["Alertmanager.monitoring.coreos.com"]
+	assert.True(t, exists, "Alertmanager.monitoring.coreos.com config should exist")
+	assert.NotNil(t, rc.additionalPrinterColumnsPriority, "additionalPrinterColumnsPriority should be set")
+	assert.Equal(t, -1, *rc.additionalPrinterColumnsPriority,
+		"Priority -1 should be stored to disable collection")
+}
+
+func TestLoadAndMergeConfigurableCollection_CollectPrinterColumnsDisabledOverriddenByPositive(t *testing.T) {
+	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
+	originalNamespace := config.Cfg.PodNamespace
+	defer func() {
+		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
+		config.Cfg.PodNamespace = originalNamespace
+		mergedTransformConfig = nil
+	}()
+
+	config.Cfg.FeatureConfigurableCollection = true
+	config.Cfg.PodNamespace = "test-namespace"
+
+	// When one rule disables (-1) and another enables (5), max wins (5).
+	collectionConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					// Rule 1: disable
+					map[string]interface{}{
+						"action": "include",
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"monitoring.coreos.com"},
+							"kinds":     []interface{}{"Alertmanager"},
+						},
+						"collectAdditionalPrinterColumnsPriority": int64(-1),
+					},
+					// Rule 2: enable with priority 5
+					map[string]interface{}{
+						"action": "include",
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"monitoring.coreos.com"},
+							"kinds":     []interface{}{"Alertmanager"},
+						},
+						"collectAdditionalPrinterColumnsPriority": int64(5),
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewSimpleDynamicClient(scheme, collectionConfig)
+
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	rc, exists := mergedTransformConfig["Alertmanager.monitoring.coreos.com"]
+	assert.True(t, exists, "Alertmanager.monitoring.coreos.com config should exist")
+	assert.NotNil(t, rc.additionalPrinterColumnsPriority, "additionalPrinterColumnsPriority should be set")
+	assert.Equal(t, 5, *rc.additionalPrinterColumnsPriority,
+		"Max priority should win — positive value (5) should override disable (-1)")
+}
+
 // TestNormalizeJSONPath verifies that the collector accepts jsonPath values both
 // with and without curly-brace wrapping, normalizing them automatically so users
 // don't need to know the k8s jsonpath library convention.

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -8,7 +8,6 @@ type ExtractProperty struct {
 	// Denotes the priority if property is an additionalPrinterColumn
 	Priority *int // `json:"priority,omitempty"`
 	// matchLabel limits extraction to resources with this label.
-	// FUTURE: generalize with matchExpression
 	// A property to denote that we should only extract this property if this label matches the resource FUTURE: generalize with matchExpression
 	matchLabel string // `json:"matchLabel,omitempty"`
 	// An internal property to denote this property should be set on the node's metadata instead.

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -5,8 +5,11 @@ type ExtractProperty struct {
 	Name     string   // `json:"name,omitempty"`
 	JSONPath string   // `json:"jsonpath,omitempty"`
 	DataType DataType // `json:"dataType,omitempty"`
+	// Denotes the priority if property is an additionalPrinterColumn
+	Priority *int // `json:"priority,omitempty"`
 	// matchLabel limits extraction to resources with this label.
 	// FUTURE: generalize with matchExpression
+	// A property to denote that we should only extract this property if this label matches the resource FUTURE: generalize with matchExpression
 	matchLabel string // `json:"matchLabel,omitempty"`
 	// An internal property to denote this property should be set on the node's metadata instead.
 	metadataOnly bool
@@ -52,10 +55,11 @@ func stringToDataType(s string) DataType {
 
 // Declares the properties to extract from a given resource.
 type ResourceConfig struct {
-	properties         []ExtractProperty // `json:"properties,omitempty"`
-	edges              []ExtractEdge     // `json:"edges,omitempty"`
-	extractAnnotations bool              // `json:"extractAnnotations,omitempty"`
-	extractConditions  bool              // `json:"extractConditions,omitempty"`
+	properties                       []ExtractProperty // `json:"properties,omitempty"`
+	edges                            []ExtractEdge     // `json:"edges,omitempty"`
+	extractAnnotations               bool              // `json:"extractAnnotations,omitempty"`
+	extractConditions                bool              // `json:"extractConditions,omitempty"`
+	additionalPrinterColumnsPriority *int              // `json:"collectAdditionalPrinterColumnsPriority,omitempty"`
 }
 
 var (
@@ -96,12 +100,12 @@ var defaultTransformConfig = map[string]ResourceConfig{
 	"ConfigMap": {
 		properties: []ExtractProperty{
 			{
-				Name: "configParamMaxDesiredLatency",
+				Name:       "configParamMaxDesiredLatency",
 				JSONPath:   `.data.spec\.param\.maxDesiredLatencyMilliseconds`,
 				matchLabel: matchLabelKiagnose,
 			},
 			{
-				Name: "configParamNADNamespace",
+				Name:       "configParamNADNamespace",
 				JSONPath:   `.data.spec\.param\.networkAttachmentDefinitionNamespace`,
 				matchLabel: matchLabelKiagnose,
 			},


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-32738

### Description of changes
- Added ability to configure collection of additional printer columns via configurable collection
- Pending CRD and webhook updates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Additional printer columns can have per-column priorities; collection is gated by configurable priority thresholds (including wildcard defaults) so only columns within the threshold are included.

* **Tests**
  * Added tests covering priority parsing, threshold-based filtering, wildcard/default threshold behavior, conflict-resolution (max-wins), and combined collection of regular properties plus printer columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->