### PR TITLE
ACM-30891 - ConfigurableCollection collect annotations

### DIFF
--- a/pkg/transforms/configurableCollection.go
+++ b/pkg/transforms/configurableCollection.go
@@ -109,11 +109,12 @@ func loadAndMergeConfigurableCollectionWithClient(dynamicClient dynamic.Interfac
 
 		hasFields := len(rule.Fields) > 0
 		hasCollectConditions := rule.CollectConditions != nil && *rule.CollectConditions
+		hasCollectAnnotations := rule.CollectAnnotations != nil && *rule.CollectAnnotations
 
-		// Only process rules that have fields specified
-		if !hasFields && !hasCollectConditions {
-			msg := "Rule skipped: include action requires at least one field or collectConditions"
-			klog.Warning("Skipping collection rule. Include action without fields or collectConditions specified.")
+		// Only process rules that have actionable configuration
+		if !hasFields && !hasCollectConditions && !hasCollectAnnotations {
+			msg := "Rule skipped: include action requires at least one field, collectConditions, or collectAnnotations"
+			klog.Warning("Skipping collection rule. Include action without fields, collectConditions, or collectAnnotations specified.")
 			warnings = append(warnings, msg)
 			continue
 		}
@@ -124,6 +125,14 @@ func loadAndMergeConfigurableCollectionWithClient(dynamicClient dynamic.Interfac
 		// Process collectConditions
 		if hasCollectConditions {
 			mergeCollectConditions(apiGroups, kinds)
+			if !hasFields && !hasCollectAnnotations {
+				continue
+			}
+		}
+
+		// Process collectAnnotations
+		if hasCollectAnnotations {
+			mergeCollectAnnotations(apiGroups, kinds)
 			if !hasFields {
 				continue
 			}
@@ -352,6 +361,33 @@ func mergeCollectConditions(apiGroups, kinds []string) {
 			resourceConfig.extractConditions = true
 			mergedTransformConfig[resourceKey] = resourceConfig
 			klog.V(2).Infof("Enabled condition collection for resource %s", resourceKey)
+		}
+	}
+}
+
+// mergeCollectAnnotations enables annotation extraction for the given apiGroups and kinds.
+// When kind is "*", a wildcard entry (e.g., "*" or "*.apps") is stored in mergedTransformConfig,
+// enabling annotation extraction for all resources in that apiGroup at runtime.
+// For specific kinds, extractAnnotations is set for each kind+apiGroup combination.
+func mergeCollectAnnotations(apiGroups, kinds []string) {
+	for _, apiGroup := range apiGroups {
+		for _, kind := range kinds {
+			if kind == "" {
+				continue
+			}
+			resourceKey := kind
+			if apiGroup != "" {
+				resourceKey = kind + "." + apiGroup
+			}
+			resourceConfig, exists := mergedTransformConfig[resourceKey]
+			if !exists {
+				resourceConfig = ResourceConfig{
+					properties: []ExtractProperty{},
+				}
+			}
+			resourceConfig.extractAnnotations = true
+			mergedTransformConfig[resourceKey] = resourceConfig
+			klog.V(2).Infof("Enabled annotation collection for resource %s", resourceKey)
 		}
 	}
 }

--- a/pkg/transforms/configurableCollection_test.go
+++ b/pkg/transforms/configurableCollection_test.go
@@ -2329,3 +2329,394 @@ func TestNormalizeJSONPath(t *testing.T) {
 		})
 	}
 }
+
+// ============================================================================
+// CollectAnnotations tests — mirrors the CollectConditions test suite
+// ============================================================================
+
+func TestLoadAndMergeConfigurableCollection_CollectAnnotationsWithSpecificKind(t *testing.T) {
+	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
+	originalNamespace := config.Cfg.PodNamespace
+	defer func() {
+		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
+		config.Cfg.PodNamespace = originalNamespace
+		mergedTransformConfig = nil
+	}()
+
+	config.Cfg.FeatureConfigurableCollection = true
+	config.Cfg.PodNamespace = "test-namespace"
+
+	collectAnnotations := true
+	collectionConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					map[string]interface{}{
+						"action":             "include",
+						"collectAnnotations": collectAnnotations,
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"apps"},
+							"kinds":     []interface{}{"Deployment"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewSimpleDynamicClient(scheme, collectionConfig)
+
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	deployConfig, exists := mergedTransformConfig["Deployment.apps"]
+	assert.True(t, exists, "Deployment.apps config should exist")
+	assert.True(t, deployConfig.extractAnnotations, "extractAnnotations should be true")
+}
+
+func TestLoadAndMergeConfigurableCollection_CollectAnnotationsWithMultipleKinds(t *testing.T) {
+	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
+	originalNamespace := config.Cfg.PodNamespace
+	defer func() {
+		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
+		config.Cfg.PodNamespace = originalNamespace
+		mergedTransformConfig = nil
+	}()
+
+	config.Cfg.FeatureConfigurableCollection = true
+	config.Cfg.PodNamespace = "test-namespace"
+
+	collectAnnotations := true
+	collectionConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					map[string]interface{}{
+						"action":             "include",
+						"collectAnnotations": collectAnnotations,
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"apps"},
+							"kinds":     []interface{}{"Deployment", "StatefulSet"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewSimpleDynamicClient(scheme, collectionConfig)
+
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	deployConfig, exists := mergedTransformConfig["Deployment.apps"]
+	assert.True(t, exists, "Deployment.apps config should exist")
+	assert.True(t, deployConfig.extractAnnotations, "Deployment extractAnnotations should be true")
+
+	ssConfig, exists := mergedTransformConfig["StatefulSet.apps"]
+	assert.True(t, exists, "StatefulSet.apps config should exist")
+	assert.True(t, ssConfig.extractAnnotations, "StatefulSet extractAnnotations should be true")
+}
+
+func TestLoadAndMergeConfigurableCollection_CollectAnnotationsWildcardKind(t *testing.T) {
+	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
+	originalNamespace := config.Cfg.PodNamespace
+	defer func() {
+		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
+		config.Cfg.PodNamespace = originalNamespace
+		mergedTransformConfig = nil
+	}()
+
+	config.Cfg.FeatureConfigurableCollection = true
+	config.Cfg.PodNamespace = "test-namespace"
+
+	collectAnnotations := true
+	collectionConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					map[string]interface{}{
+						"action":             "include",
+						"collectAnnotations": collectAnnotations,
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"apps"},
+							"kinds":     []interface{}{"*"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewSimpleDynamicClient(scheme, collectionConfig)
+
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	wildcardConfig, exists := mergedTransformConfig["*.apps"]
+	assert.True(t, exists, "*.apps wildcard config should exist in mergedTransformConfig")
+	assert.True(t, wildcardConfig.extractAnnotations, "*.apps extractAnnotations should be true")
+}
+
+func TestLoadAndMergeConfigurableCollection_CollectAnnotationsMultipleApiGroups(t *testing.T) {
+	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
+	originalNamespace := config.Cfg.PodNamespace
+	defer func() {
+		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
+		config.Cfg.PodNamespace = originalNamespace
+		mergedTransformConfig = nil
+	}()
+
+	config.Cfg.FeatureConfigurableCollection = true
+	config.Cfg.PodNamespace = "test-namespace"
+
+	collectAnnotations := true
+	collectionConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					map[string]interface{}{
+						"action":             "include",
+						"collectAnnotations": collectAnnotations,
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"apps", "batch"},
+							"kinds":     []interface{}{"*"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewSimpleDynamicClient(scheme, collectionConfig)
+
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	appsConfig, exists := mergedTransformConfig["*.apps"]
+	assert.True(t, exists, "*.apps wildcard config should exist")
+	assert.True(t, appsConfig.extractAnnotations, "*.apps extractAnnotations should be true")
+
+	batchConfig, exists := mergedTransformConfig["*.batch"]
+	assert.True(t, exists, "*.batch wildcard config should exist")
+	assert.True(t, batchConfig.extractAnnotations, "*.batch extractAnnotations should be true")
+}
+
+func TestLoadAndMergeConfigurableCollection_CollectAnnotationsWithFieldsAndKind(t *testing.T) {
+	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
+	originalNamespace := config.Cfg.PodNamespace
+	defer func() {
+		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
+		config.Cfg.PodNamespace = originalNamespace
+		mergedTransformConfig = nil
+	}()
+
+	config.Cfg.FeatureConfigurableCollection = true
+	config.Cfg.PodNamespace = "test-namespace"
+
+	collectAnnotations := true
+	collectionConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					map[string]interface{}{
+						"action":             "include",
+						"collectAnnotations": collectAnnotations,
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"apps"},
+							"kinds":     []interface{}{"Deployment"},
+						},
+						"fields": []interface{}{
+							map[string]interface{}{
+								"name":     "replicas",
+								"jsonPath": "{.spec.replicas}",
+								"type":     "number",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewSimpleDynamicClient(scheme, collectionConfig)
+
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	deployConfig, exists := mergedTransformConfig["Deployment.apps"]
+	assert.True(t, exists, "Deployment.apps config should exist")
+	assert.True(t, deployConfig.extractAnnotations, "extractAnnotations should be true")
+	assert.Equal(t, 1, len(deployConfig.properties), "Should have 1 custom field")
+	assert.Equal(t, "replicas", deployConfig.properties[0].Name)
+	assert.Equal(t, DataTypeNumber, deployConfig.properties[0].DataType)
+}
+
+func TestLoadAndMergeConfigurableCollection_CollectAnnotationsPreservesDefaults(t *testing.T) {
+	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
+	originalNamespace := config.Cfg.PodNamespace
+	defer func() {
+		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
+		config.Cfg.PodNamespace = originalNamespace
+		mergedTransformConfig = nil
+	}()
+
+	config.Cfg.FeatureConfigurableCollection = true
+	config.Cfg.PodNamespace = "test-namespace"
+
+	// Empty rules - verify defaults are preserved
+	collectionConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewSimpleDynamicClient(scheme, collectionConfig)
+
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	// Verify defaults with extractAnnotations are preserved
+	dvConfig, exists := mergedTransformConfig["DataVolume.cdi.kubevirt.io"]
+	assert.True(t, exists, "DataVolume.cdi.kubevirt.io config should exist from defaults")
+	assert.True(t, dvConfig.extractAnnotations, "DataVolume should retain default extractAnnotations=true")
+
+	nadConfig, exists := mergedTransformConfig["NetworkAttachmentDefinition.k8s.cni.cncf.io"]
+	assert.True(t, exists, "NetworkAttachmentDefinition.k8s.cni.cncf.io config should exist from defaults")
+	assert.True(t, nadConfig.extractAnnotations, "NetworkAttachmentDefinition should retain default extractAnnotations=true")
+}
+
+func TestLoadAndMergeConfigurableCollection_CollectAnnotationsCoreApiGroup(t *testing.T) {
+	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
+	originalNamespace := config.Cfg.PodNamespace
+	defer func() {
+		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
+		config.Cfg.PodNamespace = originalNamespace
+		mergedTransformConfig = nil
+	}()
+
+	config.Cfg.FeatureConfigurableCollection = true
+	config.Cfg.PodNamespace = "test-namespace"
+
+	collectAnnotations := true
+	collectionConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					map[string]interface{}{
+						"action":             "include",
+						"collectAnnotations": collectAnnotations,
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{""},
+							"kinds":     []interface{}{"*"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewSimpleDynamicClient(scheme, collectionConfig)
+
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	// Core API group is empty string - wildcard key is just "*" (no dot prefix)
+	coreConfig, exists := mergedTransformConfig["*"]
+	assert.True(t, exists, "* wildcard config should exist for core API group")
+	assert.True(t, coreConfig.extractAnnotations, "* extractAnnotations should be true")
+}
+
+func TestLoadAndMergeConfigurableCollection_CollectAnnotationsOnly(t *testing.T) {
+	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
+	originalNamespace := config.Cfg.PodNamespace
+	defer func() {
+		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
+		config.Cfg.PodNamespace = originalNamespace
+		mergedTransformConfig = nil
+	}()
+
+	config.Cfg.FeatureConfigurableCollection = true
+	config.Cfg.PodNamespace = "test-namespace"
+
+	// Rule with only collectAnnotations — no fields, no collectConditions.
+	// This should NOT be skipped by the guard clause.
+	collectAnnotations := true
+	collectionConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					map[string]interface{}{
+						"action":             "include",
+						"collectAnnotations": collectAnnotations,
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"apps"},
+							"kinds":     []interface{}{"Deployment"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewSimpleDynamicClient(scheme, collectionConfig)
+
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	deployConfig, exists := mergedTransformConfig["Deployment.apps"]
+	assert.True(t, exists, "Deployment.apps config should exist — collectAnnotations-only rule must not be skipped")
+	assert.True(t, deployConfig.extractAnnotations, "extractAnnotations should be true")
+	assert.Empty(t, deployConfig.properties, "Should have no custom fields")
+	assert.False(t, deployConfig.extractConditions, "extractConditions should be false")
+}


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-30891

### Description of changes
- Added ability to configure collection of annotations with configurable collection


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for collecting annotations in configurable collection rules. Users can now configure rules with `collectAnnotations` to extract annotations from Kubernetes resources, complementing existing field and condition collection approaches.

* **Tests**
  * Added comprehensive test coverage for the new annotation collection feature, including scenarios with specific kinds, multiple kinds, wildcard matching, and multiple API groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->