### PR TITLE
ACM-35522: Implement exclude action for CollectorConfig collection rules

### DIFF
--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -17,6 +17,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// msgSkippingExcluded is the log format for resources skipped by an exclude rule.
+const msgSkippingExcluded = "Skipping excluded resource. Kind: %s Group: %s"
+
 // GenericInformer ...
 type GenericInformer struct {
 	client        dynamic.Interface
@@ -112,7 +115,7 @@ func (inform *GenericInformer) listAndResync() error {
 				continue
 			}
 			if transforms.IsResourceExcluded(inform.gvr.Group, resources.Items[i].GetKind()) {
-				klog.V(4).Infof("Skipping excluded resource. Kind: %s Group: %s",
+				klog.V(4).Infof(msgSkippingExcluded,
 					resources.Items[i].GetKind(), inform.gvr.Group)
 				continue
 			}
@@ -189,7 +192,7 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 					continue
 				}
 				if transforms.IsResourceExcluded(inform.gvr.Group, obj.GetKind()) {
-					klog.V(4).Infof("Skipping excluded resource. Kind: %s Group: %s",
+					klog.V(4).Infof(msgSkippingExcluded,
 						obj.GetKind(), inform.gvr.Group)
 					continue
 				}
@@ -217,7 +220,7 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 					continue
 				}
 				if transforms.IsResourceExcluded(inform.gvr.Group, obj.GetKind()) {
-					klog.V(4).Infof("Skipping excluded resource. Kind: %s Group: %s",
+					klog.V(4).Infof(msgSkippingExcluded,
 						obj.GetKind(), inform.gvr.Group)
 					continue
 				}

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stolostron/search-collector/pkg/config"
+	"github.com/stolostron/search-collector/pkg/transforms"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -105,9 +106,14 @@ func (inform *GenericInformer) listAndResync() error {
 			return listError
 		}
 
-		// Add all resources filtered by namespace
+		// Add all resources filtered by namespace and exclude rules.
 		for i := range resources.Items {
 			if !nsFilterCache.isNamespaceAllowed(resources.Items[i].GetNamespace()) {
+				continue
+			}
+			if transforms.IsResourceExcluded(inform.gvr.Group, resources.Items[i].GetKind()) {
+				klog.V(4).Infof("Skipping excluded resource. Kind: %s Group: %s",
+					resources.Items[i].GetKind(), inform.gvr.Group)
 				continue
 			}
 
@@ -182,6 +188,11 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 				if !nsFilterCache.isNamespaceAllowed(obj.GetNamespace()) {
 					continue
 				}
+				if transforms.IsResourceExcluded(inform.gvr.Group, obj.GetKind()) {
+					klog.V(4).Infof("Skipping excluded resource. Kind: %s Group: %s",
+						obj.GetKind(), inform.gvr.Group)
+					continue
+				}
 				// Namespace additions affect which resources pass the namespace filter.
 				if inform.gvr.Resource == "namespaces" && inform.gvr.Group == "" {
 					nsFilterCache.regenerate()
@@ -203,6 +214,11 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 				//   for example invalidate the namespace filter cache on CollectorConfig changes
 				//   https://github.com/stolostron/search-collector/pull/866#discussion_r3196850432
 				if !nsFilterCache.isNamespaceAllowed(obj.GetNamespace()) {
+					continue
+				}
+				if transforms.IsResourceExcluded(inform.gvr.Group, obj.GetKind()) {
+					klog.V(4).Infof("Skipping excluded resource. Kind: %s Group: %s",
+						obj.GetKind(), inform.gvr.Group)
 					continue
 				}
 				// Namespace changes affect which resources pass the namespace filter.

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -9,16 +9,12 @@ import (
 	"time"
 
 	"github.com/stolostron/search-collector/pkg/config"
-	"github.com/stolostron/search-collector/pkg/transforms"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
 )
-
-// msgSkippingExcluded is the log format for resources skipped by an exclude rule.
-const msgSkippingExcluded = "Skipping excluded resource. Kind: %s Group: %s"
 
 // GenericInformer ...
 type GenericInformer struct {
@@ -109,14 +105,11 @@ func (inform *GenericInformer) listAndResync() error {
 			return listError
 		}
 
-		// Add all resources filtered by namespace and exclude rules.
+		// Add all resources filtered by namespace.
+		// Excluded resource types never reach this point — they are filtered out in
+		// SupportedResources() at discovery time so no informer is created for them.
 		for i := range resources.Items {
 			if !nsFilterCache.isNamespaceAllowed(resources.Items[i].GetNamespace()) {
-				continue
-			}
-			if transforms.IsResourceExcluded(inform.gvr.Group, resources.Items[i].GetKind()) {
-				klog.V(4).Infof(msgSkippingExcluded,
-					resources.Items[i].GetKind(), inform.gvr.Group)
 				continue
 			}
 
@@ -191,11 +184,6 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 				if !nsFilterCache.isNamespaceAllowed(obj.GetNamespace()) {
 					continue
 				}
-				if transforms.IsResourceExcluded(inform.gvr.Group, obj.GetKind()) {
-					klog.V(4).Infof(msgSkippingExcluded,
-						obj.GetKind(), inform.gvr.Group)
-					continue
-				}
 				// Namespace additions affect which resources pass the namespace filter.
 				if inform.gvr.Resource == "namespaces" && inform.gvr.Group == "" {
 					nsFilterCache.regenerate()
@@ -217,11 +205,6 @@ func (inform *GenericInformer) watch(stopper <-chan struct{}) {
 				//   for example invalidate the namespace filter cache on CollectorConfig changes
 				//   https://github.com/stolostron/search-collector/pull/866#discussion_r3196850432
 				if !nsFilterCache.isNamespaceAllowed(obj.GetNamespace()) {
-					continue
-				}
-				if transforms.IsResourceExcluded(inform.gvr.Group, obj.GetKind()) {
-					klog.V(4).Infof(msgSkippingExcluded,
-						obj.GetKind(), inform.gvr.Group)
 					continue
 				}
 				// Namespace changes affect which resources pass the namespace filter.

--- a/pkg/informer/supportedResources.go
+++ b/pkg/informer/supportedResources.go
@@ -142,6 +142,18 @@ func SupportedResources(discoveryClient discovery.DiscoveryClient) (map[schema.G
 				continue // Skip the resource before starting the informer
 			}
 
+			// Skip resources excluded via CollectorConfig exclude rules.
+			// Normalize the group to empty string for core-group resources ("v1" → "")
+			// to match the CollectorConfig apiGroups convention.
+			apiGroup := group
+			if len(groupVersion) == 1 {
+				apiGroup = ""
+			}
+			if tr.IsResourceExcluded(apiGroup, apiResource.Kind) {
+				klog.V(3).Infof("Skipping excluded resource [group: '%s' kind: %s]. Matched CollectorConfig exclude rule.", apiGroup, apiResource.Kind)
+				continue
+			}
+
 			// add non-namespaced resource to NonNSResourceMap
 			if !apiResource.Namespaced {
 				tr.NonNSResMapMutex.Lock()

--- a/pkg/informer/supportedResources.go
+++ b/pkg/informer/supportedResources.go
@@ -150,7 +150,8 @@ func SupportedResources(discoveryClient discovery.DiscoveryClient) (map[schema.G
 				apiGroup = ""
 			}
 			if tr.IsResourceExcluded(apiGroup, apiResource.Kind) {
-				klog.V(3).Infof("Skipping excluded resource [group: '%s' kind: %s]. Matched CollectorConfig exclude rule.", apiGroup, apiResource.Kind)
+				klog.V(3).Infof("Skipping excluded resource [group: '%s' kind: %s]."+
+					" Matched CollectorConfig exclude rule.", apiGroup, apiResource.Kind)
 				continue
 			}
 

--- a/pkg/informer/supportedResources.go
+++ b/pkg/informer/supportedResources.go
@@ -151,7 +151,7 @@ func SupportedResources(discoveryClient discovery.DiscoveryClient) (map[schema.G
 			}
 			if tr.IsResourceExcluded(apiGroup, apiResource.Kind) {
 				klog.V(3).Infof("Skipping excluded resource [group: '%s' kind: %s]."+
-					" Matched CollectorConfig exclude rule.", apiGroup, apiResource.Kind)
+					" Matched CollectorConfig exclude rule.", apiGroup, apiResource.Name)
 				continue
 			}
 

--- a/pkg/transforms/configurableCollection.go
+++ b/pkg/transforms/configurableCollection.go
@@ -20,13 +20,19 @@ import (
 // Wildcard entries like "*" (core group) or "*.apps" are used for apigroup-wide collectConditions.
 var mergedTransformConfig map[string]ResourceConfig
 
+// excludedResources holds the set of resource keys that should not be collected.
+// Keys follow the same scheme as mergedTransformConfig: "Kind.apiGroup" for specific kinds,
+// "*" for all core-group resources, "*.apps" for all resources in the apps apiGroup.
+// Populated by mergeExcludeRules during config load; checked at the informer layer.
+var excludedResources map[string]struct{}
+
 // LoadAndMergeConfigurableCollection loads the CollectorConfig resource from the cluster and merges it with defaultTransformConfig.
 // The merged result is stored in mergedTransformConfig.
 func LoadAndMergeConfigurableCollection() {
 	if !config.Cfg.FeatureConfigurableCollection {
 		klog.Info("Configurable collection feature is disabled, skipping custom config load")
-		// Initialize mergedTransformConfig to a copy of defaultTransformConfig
 		mergedTransformConfig = deepCopyTransformConfig(defaultTransformConfig)
+		excludedResources = map[string]struct{}{}
 		return
 	}
 
@@ -54,8 +60,9 @@ var collectorConfigGVR = schema.GroupVersionResource{
 
 // loadAndMergeConfigurableCollectionWithClient is a helper function that accepts a dynamic client for testability.
 func loadAndMergeConfigurableCollectionWithClient(dynamicClient dynamic.Interface) {
-	// Start with a deep copy of defaultTransformConfig
+	// Start with a deep copy of defaultTransformConfig and a fresh exclude set.
 	mergedTransformConfig = deepCopyTransformConfig(defaultTransformConfig)
+	excludedResources = map[string]struct{}{}
 
 	namespace := config.Cfg.PodNamespace
 
@@ -99,13 +106,16 @@ func loadAndMergeConfigurableCollectionWithClient(dynamicClient dynamic.Interfac
 		// Get field suffix for this rule (defaults to empty string)
 		fieldSuffix := rule.FieldSuffix
 
-		// FUTURE: Only Include actions are currently supported
-		if rule.Action != v1alpha1.ActionInclude {
-			msg := fmt.Sprintf("Rule skipped: only \"include\" action is supported, found %q", rule.Action)
-			klog.Warningf("Skipping collection rule. Only \"include\" action supported at this time: %s", rule.Action)
-			warnings = append(warnings, msg)
+		if rule.Action == v1alpha1.ActionExclude {
+			mergeExcludeRules(rule.ResourceSelector.APIGroups, rule.ResourceSelector.Kinds)
 			continue
 		}
+
+		// "Last entry wins": an include rule cancels any prior exclude for the same resource.
+		// Uses the same key scheme as mergeExcludeRules so exact keys are matched and removed.
+		// Note: wildcard-vs-specific mismatches (e.g. exclude "*.*" followed by include
+		// "Deployment.apps") are not resolved — those are documented as a known limitation.
+		unmergeExcludeRules(rule.ResourceSelector.APIGroups, rule.ResourceSelector.Kinds)
 
 		hasFields := len(rule.Fields) > 0
 		hasCollectConditions := rule.CollectConditions != nil && *rule.CollectConditions
@@ -340,6 +350,83 @@ func updateCollectorConfigStatus(dynamicClient dynamic.Interface, namespace stri
 		return
 	}
 	klog.V(2).Infof("Updated CollectorConfig status: Applied=%s reason=%s", conditionStatus, reason)
+}
+
+// mergeExcludeRules records the given apiGroups+kinds in excludedResources so they are
+// skipped at the informer layer. Follows the same key scheme as mergedTransformConfig:
+// - specific kind:  "Lease.coordination.k8s.io"
+// - all kinds in group:  "*.coordination.k8s.io"
+// - all core-group kinds: "*"
+func mergeExcludeRules(apiGroups, kinds []string) {
+	for _, apiGroup := range apiGroups {
+		for _, kind := range kinds {
+			if kind == "" {
+				continue
+			}
+			resourceKey := kind
+			if apiGroup != "" {
+				resourceKey = kind + "." + apiGroup
+			}
+			excludedResources[resourceKey] = struct{}{}
+			klog.V(2).Infof("Excluding resource from collection: %s", resourceKey)
+		}
+	}
+}
+
+// unmergeExcludeRules removes the given apiGroups+kinds from excludedResources.
+// Called when an include rule follows an exclude for the same resource so that the
+// include wins ("last entry wins" semantics within a single CollectorConfig).
+func unmergeExcludeRules(apiGroups, kinds []string) {
+	for _, apiGroup := range apiGroups {
+		for _, kind := range kinds {
+			if kind == "" {
+				continue
+			}
+			resourceKey := kind
+			if apiGroup != "" {
+				resourceKey = kind + "." + apiGroup
+			}
+			delete(excludedResources, resourceKey)
+			klog.V(2).Infof("Include rule cancels prior exclude for resource %s", resourceKey)
+		}
+	}
+}
+
+// IsResourceExcluded reports whether a resource should be excluded from collection.
+// Checks in order:
+//  1. Exact match:          "Lease.coordination.k8s.io" / "Event" (core group)
+//  2. Kind wildcard:        "*.coordination.k8s.io"     / "*" (core group)
+//  3. Group wildcard:       "Lease.*"  (any apiGroup for this kind) — not common, but consistent
+//  4. Global wildcard:      "*.*"      (all kinds in all groups)
+func IsResourceExcluded(group, kind string) bool {
+	if excludedResources == nil {
+		return false
+	}
+	// 1. Exact match
+	exactKey := kind
+	if group != "" {
+		exactKey = kind + "." + group
+	}
+	if _, ok := excludedResources[exactKey]; ok {
+		return true
+	}
+	// 2. Wildcard kind for this group: "*.group" or "*" (core)
+	kindWildcard := "*"
+	if group != "" {
+		kindWildcard = "*." + group
+	}
+	if _, ok := excludedResources[kindWildcard]; ok {
+		return true
+	}
+	// 3. This kind in any group: "Kind.*"
+	if group != "" {
+		if _, ok := excludedResources[kind+".*"]; ok {
+			return true
+		}
+	}
+	// 4. Global wildcard: "*.*" (all kinds across all apiGroups)
+	_, ok := excludedResources["*.*"]
+	return ok
 }
 
 // mergeCollectConditions enables condition extraction for the given apiGroups and kinds.

--- a/pkg/transforms/configurableCollection.go
+++ b/pkg/transforms/configurableCollection.go
@@ -20,16 +20,31 @@ import (
 // Wildcard entries like "*" (core group) or "*.apps" are used for apigroup-wide collectConditions.
 var mergedTransformConfig map[string]ResourceConfig
 
-// excludedResources holds the set of resource keys that should not be collected.
-// Keys follow the same scheme as mergedTransformConfig: "Kind.apiGroup" for specific kinds,
-// "*" for all core-group resources, "*.apps" for all resources in the apps apiGroup.
-// Populated by mergeExcludeRules during config load; checked at the informer layer.
+// excludeRule is a single entry in the ordered exclude/include evaluation list.
+// Each rule is a cartesian product of apiGroups × kinds. Action determines whether
+// matching resources are excluded (ActionExclude) or whether a prior exclude is
+// cancelled (ActionInclude). Rules are evaluated in the order they appear in
+// merged-collector-config; the last matching rule determines the final outcome
+// ("last entry wins").
 //
-// Thread safety: currently written once at startup (before informers start) and read
-// concurrently by informer goroutines. Safe for now because reads begin only after
-// LoadAndMergeConfigurableCollection returns. When ACM-20047 adds dynamic reload,
-// this will need a sync.RWMutex — see nsFilterCache for the expected pattern.
-var excludedResources map[string]struct{}
+// This mirrors the matching logic of isResourceMatchingList in pkg/informer/supportedResources.go
+// so that CollectorConfig exclude behaviour is consistent with the legacy ConfigMap Allow/Deny
+// feature it is intended to replace (ACM-21892).
+type excludeRule struct {
+	apiGroups []string
+	kinds     []string
+	action    v1alpha1.ActionType
+}
+
+// excludeRules is the ordered list of exclude / include-override rules built during
+// config load. IsResourceExcluded walks the list and returns the action of the last
+// matching rule (false = include, true = exclude). An empty list means no resources
+// are excluded.
+//
+// Thread safety: written once at startup, then read concurrently by informer goroutines.
+// Safe for now because reads only begin after LoadAndMergeConfigurableCollection returns.
+// When ACM-20047 adds dynamic reload, this will need a sync.RWMutex.
+var excludeRules []excludeRule
 
 // LoadAndMergeConfigurableCollection loads the CollectorConfig resource from the cluster and merges it with defaultTransformConfig.
 // The merged result is stored in mergedTransformConfig.
@@ -37,7 +52,7 @@ func LoadAndMergeConfigurableCollection() {
 	if !config.Cfg.FeatureConfigurableCollection {
 		klog.Info("Configurable collection feature is disabled, skipping custom config load")
 		mergedTransformConfig = deepCopyTransformConfig(defaultTransformConfig)
-		excludedResources = map[string]struct{}{}
+		excludeRules = nil
 		return
 	}
 
@@ -65,9 +80,9 @@ var collectorConfigGVR = schema.GroupVersionResource{
 
 // loadAndMergeConfigurableCollectionWithClient is a helper function that accepts a dynamic client for testability.
 func loadAndMergeConfigurableCollectionWithClient(dynamicClient dynamic.Interface) {
-	// Start with a deep copy of defaultTransformConfig and a fresh exclude set.
+	// Start with a deep copy of defaultTransformConfig and a fresh exclude rule list.
 	mergedTransformConfig = deepCopyTransformConfig(defaultTransformConfig)
-	excludedResources = map[string]struct{}{}
+	excludeRules = nil
 
 	namespace := config.Cfg.PodNamespace
 
@@ -112,7 +127,7 @@ func loadAndMergeConfigurableCollectionWithClient(dynamicClient dynamic.Interfac
 		fieldSuffix := rule.FieldSuffix
 
 		if rule.Action == v1alpha1.ActionExclude {
-			mergeExcludeRules(rule.ResourceSelector.APIGroups, rule.ResourceSelector.Kinds)
+			appendExcludeRule(rule.ResourceSelector.APIGroups, rule.ResourceSelector.Kinds, v1alpha1.ActionExclude)
 			continue
 		}
 
@@ -130,11 +145,11 @@ func loadAndMergeConfigurableCollectionWithClient(dynamicClient dynamic.Interfac
 			continue
 		}
 
-		// "Last entry wins": a valid include rule cancels any prior exclude for the same resource.
-		// Uses the same key scheme as mergeExcludeRules so exact keys are matched and removed.
-		// Note: wildcard-vs-specific mismatches (e.g. exclude "*.*" followed by include
-		// "Deployment.apps") are not resolved — those are documented as a known limitation.
-		unmergeExcludeRules(rule.ResourceSelector.APIGroups, rule.ResourceSelector.Kinds)
+		// "Last entry wins": a valid include rule appends an ActionInclude entry to excludeRules,
+		// which cancels any prior exclude for the same resource during IsResourceExcluded evaluation.
+		// This correctly handles wildcard-vs-specific (e.g. exclude "*.*" followed by
+		// include "Deployment.apps" → Deployments are NOT excluded).
+		appendExcludeRule(rule.ResourceSelector.APIGroups, rule.ResourceSelector.Kinds, v1alpha1.ActionInclude)
 
 		apiGroups := rule.ResourceSelector.APIGroups
 		kinds := rule.ResourceSelector.Kinds
@@ -358,79 +373,52 @@ func updateCollectorConfigStatus(dynamicClient dynamic.Interface, namespace stri
 	klog.V(2).Infof("Updated CollectorConfig status: Applied=%s reason=%s", conditionStatus, reason)
 }
 
-// mergeExcludeRules records the given apiGroups+kinds in excludedResources so they are
-// skipped at the informer layer. Follows the same key scheme as mergedTransformConfig:
-// - specific kind:  "Lease.coordination.k8s.io"
-// - all kinds in group:  "*.coordination.k8s.io"
-// - all core-group kinds: "*"
-func mergeExcludeRules(apiGroups, kinds []string) {
-	for _, apiGroup := range apiGroups {
-		for _, kind := range kinds {
-			if kind == "" {
-				continue
-			}
-			resourceKey := kind
-			if apiGroup != "" {
-				resourceKey = kind + "." + apiGroup
-			}
-			excludedResources[resourceKey] = struct{}{}
-			klog.V(2).Infof("Excluding resource from collection: %s", resourceKey)
-		}
+// appendExcludeRule appends an exclude or include-override rule to the ordered rule list.
+// The rule matches any combination of (apiGroup, kind) from the cartesian product of
+// apiGroups × kinds, using "*" as a wildcard for either dimension. This is consistent
+// with the matching logic in pkg/informer/supportedResources.go (isResourceMatchingList).
+func appendExcludeRule(apiGroups, kinds []string, action v1alpha1.ActionType) {
+	if len(apiGroups) == 0 || len(kinds) == 0 {
+		return
 	}
+	excludeRules = append(excludeRules, excludeRule{
+		apiGroups: apiGroups,
+		kinds:     kinds,
+		action:    action,
+	})
+	klog.V(2).Infof("Appended %s rule: apiGroups=%v kinds=%v", action, apiGroups, kinds)
 }
 
-// unmergeExcludeRules removes the given apiGroups+kinds from excludedResources.
-// Called when an include rule follows an exclude for the same resource so that the
-// include wins ("last entry wins" semantics within a single CollectorConfig).
-func unmergeExcludeRules(apiGroups, kinds []string) {
-	for _, apiGroup := range apiGroups {
-		for _, kind := range kinds {
-			if kind == "" {
-				continue
+// matchesExcludeRule reports whether (group, kind) is matched by a rule's apiGroups × kinds.
+// Uses the same cartesian wildcard logic as pkg/informer/supportedResources.go:
+//   - "*" in apiGroups matches any group (including core group "")
+//   - "*" in kinds matches any kind
+func matchesExcludeRule(group, kind string, apiGroups, kinds []string) bool {
+	for _, g := range apiGroups {
+		for _, k := range kinds {
+			if (g == "*" || g == group) && (k == "*" || k == kind) {
+				return true
 			}
-			resourceKey := kind
-			if apiGroup != "" {
-				resourceKey = kind + "." + apiGroup
-			}
-			delete(excludedResources, resourceKey)
-			klog.V(2).Infof("Include rule cancels prior exclude for resource %s", resourceKey)
 		}
 	}
+	return false
 }
 
 // IsResourceExcluded reports whether a resource should be excluded from collection.
-// Checks in order:
-//  1. Exact match:          "Lease.coordination.k8s.io" / "Event" (core group)
-//  2. Kind wildcard:        "*.coordination.k8s.io"     / "*" (core group)
-//  3. Group wildcard:       "Lease.*"  (any apiGroup for this kind) — not common, but consistent
-//  4. Global wildcard:      "*.*"      (all kinds in all groups)
+// Evaluates the ordered excludeRules list with "last matching rule wins" semantics:
+//   - An ActionExclude rule that matches marks the resource as excluded.
+//   - An ActionInclude rule that matches cancels any prior exclude.
+//
+// This resolves wildcard-vs-specific correctly: exclude "*.*" followed by
+// include "Deployment.apps" results in Deployments being collected (not excluded).
 func IsResourceExcluded(group, kind string) bool {
-	if excludedResources == nil {
-		return false
+	excluded := false
+	for _, rule := range excludeRules {
+		if matchesExcludeRule(group, kind, rule.apiGroups, rule.kinds) {
+			excluded = rule.action == v1alpha1.ActionExclude
+		}
 	}
-	// 1. Exact match
-	exactKey := kind
-	if group != "" {
-		exactKey = kind + "." + group
-	}
-	if _, ok := excludedResources[exactKey]; ok {
-		return true
-	}
-	// 2. Wildcard kind for this group: "*.group" or "*" (core)
-	kindWildcard := "*"
-	if group != "" {
-		kindWildcard = "*." + group
-	}
-	if _, ok := excludedResources[kindWildcard]; ok {
-		return true
-	}
-	// 3. This kind in any group: "Kind.*" (matches even core-group resources when apiGroups: ["*"])
-	if _, ok := excludedResources[kind+".*"]; ok {
-		return true
-	}
-	// 4. Global wildcard: "*.*" (all kinds across all apiGroups)
-	_, ok := excludedResources["*.*"]
-	return ok
+	return excluded
 }
 
 // mergeCollectConditions enables condition extraction for the given apiGroups and kinds.

--- a/pkg/transforms/configurableCollection.go
+++ b/pkg/transforms/configurableCollection.go
@@ -24,6 +24,11 @@ var mergedTransformConfig map[string]ResourceConfig
 // Keys follow the same scheme as mergedTransformConfig: "Kind.apiGroup" for specific kinds,
 // "*" for all core-group resources, "*.apps" for all resources in the apps apiGroup.
 // Populated by mergeExcludeRules during config load; checked at the informer layer.
+//
+// Thread safety: currently written once at startup (before informers start) and read
+// concurrently by informer goroutines. Safe for now because reads begin only after
+// LoadAndMergeConfigurableCollection returns. When ACM-20047 adds dynamic reload,
+// this will need a sync.RWMutex — see nsFilterCache for the expected pattern.
 var excludedResources map[string]struct{}
 
 // LoadAndMergeConfigurableCollection loads the CollectorConfig resource from the cluster and merges it with defaultTransformConfig.

--- a/pkg/transforms/configurableCollection.go
+++ b/pkg/transforms/configurableCollection.go
@@ -111,24 +111,25 @@ func loadAndMergeConfigurableCollectionWithClient(dynamicClient dynamic.Interfac
 			continue
 		}
 
-		// "Last entry wins": an include rule cancels any prior exclude for the same resource.
-		// Uses the same key scheme as mergeExcludeRules so exact keys are matched and removed.
-		// Note: wildcard-vs-specific mismatches (e.g. exclude "*.*" followed by include
-		// "Deployment.apps") are not resolved — those are documented as a known limitation.
-		unmergeExcludeRules(rule.ResourceSelector.APIGroups, rule.ResourceSelector.Kinds)
-
 		hasFields := len(rule.Fields) > 0
 		hasCollectConditions := rule.CollectConditions != nil && *rule.CollectConditions
 		hasCollectAnnotations := rule.CollectAnnotations != nil && *rule.CollectAnnotations
 		hasCollectPrinterColumns := rule.CollectAdditionalPrinterColumnsPriority != nil
 
-		// Only process rules that have actionable configuration
+		// Only process rules that have actionable configuration — check BEFORE unmerging
+		// any prior exclude, so a malformed include rule does not silently cancel an exclude.
 		if !hasFields && !hasCollectConditions && !hasCollectPrinterColumns && !hasCollectAnnotations {
 			msg := "Rule skipped: include action requires at least one field, collectConditions, collectAnnotations, or collectAdditionalPrinterColumnsPriority"
 			klog.Warning("Skipping collection rule. Include action without fields, collectConditions, collectAnnotations, or collectAdditionalPrinterColumnsPriority specified.")
 			warnings = append(warnings, msg)
 			continue
 		}
+
+		// "Last entry wins": a valid include rule cancels any prior exclude for the same resource.
+		// Uses the same key scheme as mergeExcludeRules so exact keys are matched and removed.
+		// Note: wildcard-vs-specific mismatches (e.g. exclude "*.*" followed by include
+		// "Deployment.apps") are not resolved — those are documented as a known limitation.
+		unmergeExcludeRules(rule.ResourceSelector.APIGroups, rule.ResourceSelector.Kinds)
 
 		apiGroups := rule.ResourceSelector.APIGroups
 		kinds := rule.ResourceSelector.Kinds
@@ -418,11 +419,9 @@ func IsResourceExcluded(group, kind string) bool {
 	if _, ok := excludedResources[kindWildcard]; ok {
 		return true
 	}
-	// 3. This kind in any group: "Kind.*"
-	if group != "" {
-		if _, ok := excludedResources[kind+".*"]; ok {
-			return true
-		}
+	// 3. This kind in any group: "Kind.*" (matches even core-group resources when apiGroups: ["*"])
+	if _, ok := excludedResources[kind+".*"]; ok {
+		return true
 	}
 	// 4. Global wildcard: "*.*" (all kinds across all apiGroups)
 	_, ok := excludedResources["*.*"]

--- a/pkg/transforms/configurableCollection_test.go
+++ b/pkg/transforms/configurableCollection_test.go
@@ -2212,7 +2212,8 @@ func TestStatusCondition_WarningTruncation(t *testing.T) {
 					map[string]interface{}{"name": "y", "jsonPath": "{.y}"},
 				},
 			},
-			uniqueSubstring: "apiGroup, found 2", // "exactly 1 apiGroup, found 2" — "found 2" alone also appears in rule 3 ("kind, found 2")
+			// "exactly 1 apiGroup, found 2" — "found 2" alone also appears in rule 3 ("kind, found 2")
+			uniqueSubstring: "apiGroup, found 2",
 		},
 		{
 			rule: map[string]interface{}{
@@ -3189,24 +3190,23 @@ func makeExcludeConfig(namespace, apiGroup, kind string) *unstructured.Unstructu
 	}
 }
 
-func setupExcludeTest(t *testing.T) (func(), *fake.FakeDynamicClient) {
+func setupExcludeTest(t *testing.T) func() {
 	t.Helper()
 	orig := config.Cfg.FeatureConfigurableCollection
 	origNS := config.Cfg.PodNamespace
 	config.Cfg.FeatureConfigurableCollection = true
 	config.Cfg.PodNamespace = "test-namespace"
-	scheme := runtime.NewScheme()
 	return func() {
 		config.Cfg.FeatureConfigurableCollection = orig
 		config.Cfg.PodNamespace = origNS
 		mergedTransformConfig = nil
 		excludedResources = nil
-	}, fake.NewSimpleDynamicClient(scheme)
+	}
 }
 
 // Specific kind+group is excluded.
 func TestExclude_SpecificKind(t *testing.T) {
-	teardown, _ := setupExcludeTest(t)
+	teardown := setupExcludeTest(t)
 	defer teardown()
 
 	cfg := makeExcludeConfig("test-namespace", "coordination.k8s.io", "Lease")
@@ -3223,7 +3223,7 @@ func TestExclude_SpecificKind(t *testing.T) {
 
 // Wildcard kind excludes all kinds in a group.
 func TestExclude_WildcardKind(t *testing.T) {
-	teardown, _ := setupExcludeTest(t)
+	teardown := setupExcludeTest(t)
 	defer teardown()
 
 	cfg := makeExcludeConfig("test-namespace", "coordination.k8s.io", "*")
@@ -3240,7 +3240,7 @@ func TestExclude_WildcardKind(t *testing.T) {
 
 // Wildcard group and kind excludes everything.
 func TestExclude_WildcardAll(t *testing.T) {
-	teardown, _ := setupExcludeTest(t)
+	teardown := setupExcludeTest(t)
 	defer teardown()
 
 	cfg := makeExcludeConfig("test-namespace", "*", "*")
@@ -3255,7 +3255,7 @@ func TestExclude_WildcardAll(t *testing.T) {
 
 // Core-group (empty apiGroup) specific kind is excluded.
 func TestExclude_CoreGroup(t *testing.T) {
-	teardown, _ := setupExcludeTest(t)
+	teardown := setupExcludeTest(t)
 	defer teardown()
 
 	cfg := makeExcludeConfig("test-namespace", "", "Event")
@@ -3272,7 +3272,7 @@ func TestExclude_CoreGroup(t *testing.T) {
 
 // Exclude does not affect mergedTransformConfig — default properties still extracted.
 func TestExclude_DoesNotAffectTransformConfig(t *testing.T) {
-	teardown, _ := setupExcludeTest(t)
+	teardown := setupExcludeTest(t)
 	defer teardown()
 
 	cfg := makeExcludeConfig("test-namespace", "coordination.k8s.io", "Lease")
@@ -3291,7 +3291,7 @@ func TestExclude_DoesNotAffectTransformConfig(t *testing.T) {
 
 // Last entry wins: include after exclude for same resource cancels the exclusion.
 func TestExclude_LastEntryWins_IncludeAfterExclude(t *testing.T) {
-	teardown, _ := setupExcludeTest(t)
+	teardown := setupExcludeTest(t)
 	defer teardown()
 
 	collectConditions := true
@@ -3344,7 +3344,7 @@ func TestExclude_LastEntryWins_IncludeAfterExclude(t *testing.T) {
 
 // Last entry wins: exclude after include for same resource keeps the exclusion.
 func TestExclude_LastEntryWins_ExcludeAfterInclude(t *testing.T) {
-	teardown, _ := setupExcludeTest(t)
+	teardown := setupExcludeTest(t)
 	defer teardown()
 
 	collectConditions := true
@@ -3388,7 +3388,7 @@ func TestExclude_LastEntryWins_ExcludeAfterInclude(t *testing.T) {
 
 // Group wildcard: exclude "Lease.*" matches Lease in any apiGroup.
 func TestExclude_GroupWildcard(t *testing.T) {
-	teardown, _ := setupExcludeTest(t)
+	teardown := setupExcludeTest(t)
 	defer teardown()
 
 	cfg := makeExcludeConfig("test-namespace", "*", "Lease")
@@ -3405,7 +3405,7 @@ func TestExclude_GroupWildcard(t *testing.T) {
 
 // A skipped include rule (no fields/conditions) must NOT cancel a prior exclude.
 func TestExclude_InvalidIncludeDoesNotCancelExclude(t *testing.T) {
-	teardown, _ := setupExcludeTest(t)
+	teardown := setupExcludeTest(t)
 	defer teardown()
 
 	collectConditions := true
@@ -3464,7 +3464,7 @@ func TestExclude_NilMap(t *testing.T) {
 
 // Config reload resets excludedResources — old excludes do not persist.
 func TestExclude_ResetOnReload(t *testing.T) {
-	teardown, _ := setupExcludeTest(t)
+	teardown := setupExcludeTest(t)
 	defer teardown()
 
 	// First load: exclude Lease

--- a/pkg/transforms/configurableCollection_test.go
+++ b/pkg/transforms/configurableCollection_test.go
@@ -103,7 +103,7 @@ func TestLoadAndMergeConfigurableCollection_ValidConfig(t *testing.T) {
 }
 
 // FUTURE: this should eventually appropriately include when search-collector-config merged
-// Exclude rules do not add entries to mergedTransformConfig — they populate excludedResources instead.
+// Exclude rules populate excludedResources (not mergedTransformConfig).
 func TestLoadAndMergeConfigurableCollection_ExcludePopulatesExcludedResources(t *testing.T) {
 	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
 	originalNamespace := config.Cfg.PodNamespace
@@ -3385,6 +3385,75 @@ func TestExclude_LastEntryWins_ExcludeAfterInclude(t *testing.T) {
 
 	assert.True(t, IsResourceExcluded("coordination.k8s.io", "Lease"),
 		"Last exclude should win — Lease should be excluded")
+}
+
+// Group wildcard: exclude "Lease.*" matches Lease in any apiGroup.
+func TestExclude_GroupWildcard(t *testing.T) {
+	teardown, _ := setupExcludeTest(t)
+	defer teardown()
+
+	cfg := makeExcludeConfig("test-namespace", "*", "Lease")
+	fakeClient := fake.NewSimpleDynamicClient(runtime.NewScheme(), cfg)
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	assert.True(t, IsResourceExcluded("coordination.k8s.io", "Lease"),
+		"Lease in any group should be excluded via group wildcard")
+	assert.True(t, IsResourceExcluded("", "Lease"),
+		"Core-group Lease should also be excluded via group wildcard")
+	assert.False(t, IsResourceExcluded("coordination.k8s.io", "LeaderElection"),
+		"Other kinds should not be affected")
+}
+
+// A skipped include rule (no fields/conditions) must NOT cancel a prior exclude.
+func TestExclude_InvalidIncludeDoesNotCancelExclude(t *testing.T) {
+	teardown, _ := setupExcludeTest(t)
+	defer teardown()
+
+	collectConditions := true
+	cfg := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					// Valid include first
+					map[string]interface{}{
+						"action":            "include",
+						"collectConditions": collectConditions,
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"coordination.k8s.io"},
+							"kinds":     []interface{}{"Lease"},
+						},
+					},
+					// Exclude
+					map[string]interface{}{
+						"action": "exclude",
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"coordination.k8s.io"},
+							"kinds":     []interface{}{"Lease"},
+						},
+					},
+					// Invalid include (no fields/conditions) — must NOT cancel the exclude
+					map[string]interface{}{
+						"action": "include",
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"coordination.k8s.io"},
+							"kinds":     []interface{}{"Lease"},
+						},
+					},
+				},
+			},
+		},
+	}
+	fakeClient := fake.NewSimpleDynamicClient(runtime.NewScheme(), cfg)
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	assert.True(t, IsResourceExcluded("coordination.k8s.io", "Lease"),
+		"Invalid include (no fields/conditions) must NOT cancel the prior exclude")
 }
 
 // IsResourceExcluded returns false when no exclude rules loaded (nil map).

--- a/pkg/transforms/configurableCollection_test.go
+++ b/pkg/transforms/configurableCollection_test.go
@@ -102,7 +102,6 @@ func TestLoadAndMergeConfigurableCollection_ValidConfig(t *testing.T) {
 	assert.Equal(t, DataTypeBytes, searchConfig.properties[0].DataType)
 }
 
-// FUTURE: this should eventually appropriately include when search-collector-config merged
 // Exclude rules populate excludedResources (not mergedTransformConfig).
 func TestLoadAndMergeConfigurableCollection_ExcludePopulatesExcludedResources(t *testing.T) {
 	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection

--- a/pkg/transforms/configurableCollection_test.go
+++ b/pkg/transforms/configurableCollection_test.go
@@ -102,7 +102,7 @@ func TestLoadAndMergeConfigurableCollection_ValidConfig(t *testing.T) {
 	assert.Equal(t, DataTypeBytes, searchConfig.properties[0].DataType)
 }
 
-// Exclude rules populate excludedResources (not mergedTransformConfig).
+// Exclude rules populate excludeRules (not mergedTransformConfig).
 func TestLoadAndMergeConfigurableCollection_ExcludePopulatesExcludedResources(t *testing.T) {
 	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
 	originalNamespace := config.Cfg.PodNamespace
@@ -110,7 +110,7 @@ func TestLoadAndMergeConfigurableCollection_ExcludePopulatesExcludedResources(t 
 		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
 		config.Cfg.PodNamespace = originalNamespace
 		mergedTransformConfig = nil
-		excludedResources = nil
+		excludeRules = nil
 	}()
 
 	config.Cfg.FeatureConfigurableCollection = true
@@ -146,9 +146,9 @@ func TestLoadAndMergeConfigurableCollection_ExcludePopulatesExcludedResources(t 
 	// mergedTransformConfig must not grow — exclude does not add custom properties
 	assert.Equal(t, len(defaultTransformConfig), len(mergedTransformConfig),
 		"Exclude actions should not add entries to mergedTransformConfig")
-	// excludedResources must contain the excluded key
+	// excludeRules must cause Lease to be excluded
 	assert.True(t, IsResourceExcluded("coordination.k8s.io", "Lease"),
-		"Lease.coordination.k8s.io must be in excludedResources after exclude rule")
+		"Lease.coordination.k8s.io must be excluded after exclude rule")
 }
 
 // FUTURE: this should eventually appropriately include when search-collector-config merged
@@ -1579,7 +1579,7 @@ func TestStatusCondition_Applied_ExcludeRule(t *testing.T) {
 		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
 		config.Cfg.PodNamespace = originalNamespace
 		mergedTransformConfig = nil
-		excludedResources = nil
+		excludeRules = nil
 	}()
 
 	config.Cfg.FeatureConfigurableCollection = true
@@ -1619,7 +1619,7 @@ func TestStatusCondition_Applied_ExcludeRule(t *testing.T) {
 	assert.Equal(t, "True", cond["status"], "Exclude rule is valid — Applied should be True")
 	assert.Equal(t, "Applied", cond["reason"])
 	assert.True(t, IsResourceExcluded("coordination.k8s.io", "Lease"),
-		"Lease should be in excludedResources after loading")
+		"Lease should be excluded after loading")
 }
 
 // TestStatusCondition_Applied_FieldCollision verifies that when two rules both
@@ -3200,7 +3200,7 @@ func setupExcludeTest(t *testing.T) func() {
 		config.Cfg.FeatureConfigurableCollection = orig
 		config.Cfg.PodNamespace = origNS
 		mergedTransformConfig = nil
-		excludedResources = nil
+		excludeRules = nil
 	}
 }
 
@@ -3455,14 +3455,67 @@ func TestExclude_InvalidIncludeDoesNotCancelExclude(t *testing.T) {
 		"Invalid include (no fields/conditions) must NOT cancel the prior exclude")
 }
 
-// IsResourceExcluded returns false when no exclude rules loaded (nil map).
-func TestExclude_NilMap(t *testing.T) {
-	excludedResources = nil
+// Wildcard exclude followed by specific include: the include overrides the wildcard.
+// This is the primary use-case that was previously a documented limitation.
+// A user who wants "collect only Deployments" can now write:
+//   exclude "*.*" (deny all) + include "Deployment.apps" (allow specific)
+func TestExclude_WildcardOverriddenBySpecificInclude(t *testing.T) {
+	teardown := setupExcludeTest(t)
+	defer teardown()
+
+	collectionConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					map[string]interface{}{
+						"action": "exclude",
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"*"},
+							"kinds":     []interface{}{"*"},
+						},
+					},
+					map[string]interface{}{
+						"action": "include",
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"apps"},
+							"kinds":     []interface{}{"Deployment"},
+						},
+						"fields": []interface{}{
+							map[string]interface{}{"name": "replicas", "jsonPath": ".spec.replicas"},
+						},
+					},
+				},
+			},
+		},
+	}
+	fakeClient := fake.NewSimpleDynamicClient(runtime.NewScheme(), collectionConfig)
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	// Deployment should NOT be excluded — the specific include overrides the global exclude.
 	assert.False(t, IsResourceExcluded("apps", "Deployment"),
-		"Should return false when excludedResources is nil")
+		"Specific include 'Deployment.apps' must override prior global exclude '*.*'")
+
+	// Other resources ARE excluded by the wildcard.
+	assert.True(t, IsResourceExcluded("coordination.k8s.io", "Lease"),
+		"Lease must still be excluded by global exclude '*.*'")
+	assert.True(t, IsResourceExcluded("", "ConfigMap"),
+		"ConfigMap (core group) must still be excluded by global exclude '*.*'")
 }
 
-// Config reload resets excludedResources — old excludes do not persist.
+// IsResourceExcluded returns false when excludeRules is nil (no rules loaded).
+func TestExclude_NilRules(t *testing.T) {
+	excludeRules = nil
+	assert.False(t, IsResourceExcluded("apps", "Deployment"),
+		"Should return false when excludeRules is nil")
+}
+
+// Config reload resets excludeRules — old excludes do not persist.
 func TestExclude_ResetOnReload(t *testing.T) {
 	teardown := setupExcludeTest(t)
 	defer teardown()

--- a/pkg/transforms/configurableCollection_test.go
+++ b/pkg/transforms/configurableCollection_test.go
@@ -103,12 +103,15 @@ func TestLoadAndMergeConfigurableCollection_ValidConfig(t *testing.T) {
 }
 
 // FUTURE: this should eventually appropriately include when search-collector-config merged
-func TestLoadAndMergeConfigurableCollection_SkipExcludeActions(t *testing.T) {
+// Exclude rules do not add entries to mergedTransformConfig — they populate excludedResources instead.
+func TestLoadAndMergeConfigurableCollection_ExcludePopulatesExcludedResources(t *testing.T) {
 	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
 	originalNamespace := config.Cfg.PodNamespace
 	defer func() {
 		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
 		config.Cfg.PodNamespace = originalNamespace
+		mergedTransformConfig = nil
+		excludedResources = nil
 	}()
 
 	config.Cfg.FeatureConfigurableCollection = true
@@ -128,7 +131,7 @@ func TestLoadAndMergeConfigurableCollection_SkipExcludeActions(t *testing.T) {
 						"action": "exclude",
 						"resourceSelector": map[string]interface{}{
 							"apiGroups": []interface{}{"coordination.k8s.io"},
-							"kinds":     []interface{}{"leases"},
+							"kinds":     []interface{}{"Lease"},
 						},
 					},
 				},
@@ -141,8 +144,12 @@ func TestLoadAndMergeConfigurableCollection_SkipExcludeActions(t *testing.T) {
 
 	loadAndMergeConfigurableCollectionWithClient(fakeClient)
 
-	// Verify no custom entries were added - should equal defaultTransformConfig
-	assert.Equal(t, len(defaultTransformConfig), len(mergedTransformConfig), "Exclude actions should not add custom config")
+	// mergedTransformConfig must not grow — exclude does not add custom properties
+	assert.Equal(t, len(defaultTransformConfig), len(mergedTransformConfig),
+		"Exclude actions should not add entries to mergedTransformConfig")
+	// excludedResources must contain the excluded key
+	assert.True(t, IsResourceExcluded("coordination.k8s.io", "Lease"),
+		"Lease.coordination.k8s.io must be in excludedResources after exclude rule")
 }
 
 // FUTURE: this should eventually appropriately include when search-collector-config merged
@@ -182,12 +189,11 @@ func TestLoadAndMergeConfigurableCollection_SkipIncludeWithoutFields(t *testing.
 	scheme := runtime.NewScheme()
 	fakeClient := fake.NewSimpleDynamicClient(scheme, collectionConfig)
 
-	originalLen := len(mergedTransformConfig)
-
 	loadAndMergeConfigurableCollectionWithClient(fakeClient)
 
-	// Verify no new entries were added
-	assert.Equal(t, originalLen, len(mergedTransformConfig), "Include actions without fields should not modify config")
+	// Verify no new entries were added beyond the defaults
+	assert.Equal(t, len(defaultTransformConfig), len(mergedTransformConfig),
+		"Include actions without fields should not add new entries to mergedTransformConfig")
 }
 
 func TestLoadAndMergeConfigurableCollection_InvalidMultipleKinds(t *testing.T) {
@@ -1511,8 +1517,9 @@ func TestStatusCondition_Applied_ValidConfig(t *testing.T) {
 	assert.Equal(t, "Configuration applied successfully.", cond["message"])
 }
 
-// TestStatusCondition_Applied_SkippedRule verifies that a rule with an
-// unsupported action results in Applied=False with a descriptive warning message.
+// TestStatusCondition_Applied_SkippedRule verifies that an include rule with no
+// actionable configuration (no fields, no collectConditions, no collectAnnotations)
+// results in Applied=False with a descriptive warning message.
 func TestStatusCondition_Applied_SkippedRule(t *testing.T) {
 	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
 	originalNamespace := config.Cfg.PodNamespace
@@ -1536,8 +1543,8 @@ func TestStatusCondition_Applied_SkippedRule(t *testing.T) {
 			"spec": map[string]interface{}{
 				"collectionRules": []interface{}{
 					map[string]interface{}{
-						// "exclude" is not yet supported — rule should be skipped
-						"action": "exclude",
+						// include with no fields/collectConditions/collectAnnotations — should be skipped
+						"action": "include",
 						"resourceSelector": map[string]interface{}{
 							"apiGroups": []interface{}{"coordination.k8s.io"},
 							"kinds":     []interface{}{"Lease"},
@@ -1559,9 +1566,61 @@ func TestStatusCondition_Applied_SkippedRule(t *testing.T) {
 	assert.Equal(t, "Applied", cond["type"])
 	assert.Equal(t, "False", cond["status"], "Condition status should be False when a rule is skipped")
 	assert.Equal(t, "RulesSkipped", cond["reason"])
-	// Message should mention the skipped action
 	msg, _ := cond["message"].(string)
-	assert.True(t, strings.Contains(msg, "exclude"), "Message should mention the unsupported 'exclude' action, got: %s", msg)
+	assert.True(t, strings.Contains(msg, "requires at least one field"),
+		"Message should describe why the rule was skipped, got: %s", msg)
+}
+
+// TestStatusCondition_Applied_ExcludeRule verifies that a valid exclude rule results
+// in Applied=True — exclude rules are now fully supported and should not produce warnings.
+func TestStatusCondition_Applied_ExcludeRule(t *testing.T) {
+	originalFeatureFlag := config.Cfg.FeatureConfigurableCollection
+	originalNamespace := config.Cfg.PodNamespace
+	defer func() {
+		config.Cfg.FeatureConfigurableCollection = originalFeatureFlag
+		config.Cfg.PodNamespace = originalNamespace
+		mergedTransformConfig = nil
+		excludedResources = nil
+	}()
+
+	config.Cfg.FeatureConfigurableCollection = true
+	config.Cfg.PodNamespace = "test-namespace"
+
+	collectionConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					map[string]interface{}{
+						"action": "exclude",
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"coordination.k8s.io"},
+							"kinds":     []interface{}{"Lease"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewSimpleDynamicClient(scheme, collectionConfig)
+
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	cond := getStatusConditionFromFakeClient(fakeClient)
+	require.NotNil(t, cond, "Expected a status condition to be written to the CollectorConfig CR")
+
+	assert.Equal(t, "Applied", cond["type"])
+	assert.Equal(t, "True", cond["status"], "Exclude rule is valid — Applied should be True")
+	assert.Equal(t, "Applied", cond["reason"])
+	assert.True(t, IsResourceExcluded("coordination.k8s.io", "Lease"),
+		"Lease should be in excludedResources after loading")
 }
 
 // TestStatusCondition_Applied_FieldCollision verifies that when two rules both
@@ -1782,14 +1841,14 @@ func TestStatusCondition_MultipleWarnings(t *testing.T) {
 			"metadata":   map[string]interface{}{"name": "merged-collector-config", "namespace": "test-namespace"},
 			"spec": map[string]interface{}{
 				"collectionRules": []interface{}{
-					// Rule 1: unsupported action
-					map[string]interface{}{
-						"action": "exclude",
-						"resourceSelector": map[string]interface{}{
-							"apiGroups": []interface{}{""},
-							"kinds":     []interface{}{"Pod"},
-						},
+				// Rule 1: include with no fields/collectConditions — triggers "requires at least one field"
+				map[string]interface{}{
+					"action": "include",
+					"resourceSelector": map[string]interface{}{
+						"apiGroups": []interface{}{""},
+						"kinds":     []interface{}{"Pod"},
 					},
+				},
 					// Rule 2: include without fields
 					map[string]interface{}{
 						"action": "include",
@@ -1827,7 +1886,7 @@ func TestStatusCondition_MultipleWarnings(t *testing.T) {
 	msg, _ := cond["message"].(string)
 	// All 3 warnings should be in the single message separated by "; "
 	assert.True(t, strings.Contains(msg, "; "), "Multiple warnings should be separated by '; ', got: %s", msg)
-	assert.True(t, strings.Contains(msg, "only \"include\" action is supported, found \"exclude\""), "Rule 1: got: %s", msg)
+	assert.True(t, strings.Contains(msg, "include action requires at least one field"), "Rule 1: got: %s", msg)
 	assert.True(t, strings.Contains(msg, "include action requires at least one field"), "Rule 2: got: %s", msg)
 	assert.True(t, strings.Contains(msg, "include action with fields must specify exactly 1 kind, found 2"), "Rule 3: got: %s", msg)
 }
@@ -2041,7 +2100,8 @@ func TestStatusCondition_LastTransitionTime_UpdatedWhenStatusChanges(t *testing.
 			"spec": map[string]interface{}{
 				"collectionRules": []interface{}{
 					map[string]interface{}{
-						"action": "exclude", // broken rule — triggers False
+						// include with no fields — triggers Applied=False (RulesSkipped)
+						"action": "include",
 						"resourceSelector": map[string]interface{}{
 							"apiGroups": []interface{}{""},
 							"kinds":     []interface{}{"Pod"},
@@ -2105,14 +2165,18 @@ func TestStatusCondition_WarningTruncation(t *testing.T) {
 	}
 	distinctWarningRules := []warningRule{
 		{
+			// include + fields + zero apiGroups → "exactly 1 apiGroup, found 0"
 			rule: map[string]interface{}{
-				"action": "exclude",
+				"action": "include",
 				"resourceSelector": map[string]interface{}{
-					"apiGroups": []interface{}{"coordination.k8s.io"},
-					"kinds":     []interface{}{"Lease"},
+					"apiGroups": []interface{}{}, // zero apiGroups
+					"kinds":     []interface{}{"Pod"},
+				},
+				"fields": []interface{}{
+					map[string]interface{}{"name": "v", "jsonPath": "{.v}"},
 				},
 			},
-			uniqueSubstring: `found "exclude"`,
+			uniqueSubstring: "found 0",
 		},
 		{
 			rule: map[string]interface{}{
@@ -2149,7 +2213,7 @@ func TestStatusCondition_WarningTruncation(t *testing.T) {
 					map[string]interface{}{"name": "y", "jsonPath": "{.y}"},
 				},
 			},
-			uniqueSubstring: "exactly 1 apiGroup",
+			uniqueSubstring: "apiGroup, found 2", // "exactly 1 apiGroup, found 2" — "found 2" alone also appears in rule 3 ("kind, found 2")
 		},
 		{
 			rule: map[string]interface{}{
@@ -3098,4 +3162,265 @@ func TestLoadAndMergeConfigurableCollection_CollectAnnotationsOnly(t *testing.T)
 	assert.True(t, deployConfig.extractAnnotations, "extractAnnotations should be true")
 	assert.Empty(t, deployConfig.properties, "Should have no custom fields")
 	assert.False(t, deployConfig.extractConditions, "extractConditions should be false")
+}
+
+// --- Exclude action tests ---
+
+func makeExcludeConfig(namespace, apiGroup, kind string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					map[string]interface{}{
+						"action": "exclude",
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{apiGroup},
+							"kinds":     []interface{}{kind},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func setupExcludeTest(t *testing.T) (func(), *fake.FakeDynamicClient) {
+	t.Helper()
+	orig := config.Cfg.FeatureConfigurableCollection
+	origNS := config.Cfg.PodNamespace
+	config.Cfg.FeatureConfigurableCollection = true
+	config.Cfg.PodNamespace = "test-namespace"
+	scheme := runtime.NewScheme()
+	return func() {
+		config.Cfg.FeatureConfigurableCollection = orig
+		config.Cfg.PodNamespace = origNS
+		mergedTransformConfig = nil
+		excludedResources = nil
+	}, fake.NewSimpleDynamicClient(scheme)
+}
+
+// Specific kind+group is excluded.
+func TestExclude_SpecificKind(t *testing.T) {
+	teardown, _ := setupExcludeTest(t)
+	defer teardown()
+
+	cfg := makeExcludeConfig("test-namespace", "coordination.k8s.io", "Lease")
+	fakeClient := fake.NewSimpleDynamicClient(runtime.NewScheme(), cfg)
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	assert.True(t, IsResourceExcluded("coordination.k8s.io", "Lease"),
+		"Lease.coordination.k8s.io should be excluded")
+	assert.False(t, IsResourceExcluded("coordination.k8s.io", "LeaderElection"),
+		"Other kinds in group should not be excluded")
+	assert.False(t, IsResourceExcluded("", "Lease"),
+		"Core-group Lease should not be excluded")
+}
+
+// Wildcard kind excludes all kinds in a group.
+func TestExclude_WildcardKind(t *testing.T) {
+	teardown, _ := setupExcludeTest(t)
+	defer teardown()
+
+	cfg := makeExcludeConfig("test-namespace", "coordination.k8s.io", "*")
+	fakeClient := fake.NewSimpleDynamicClient(runtime.NewScheme(), cfg)
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	assert.True(t, IsResourceExcluded("coordination.k8s.io", "Lease"),
+		"Lease should be excluded via wildcard")
+	assert.True(t, IsResourceExcluded("coordination.k8s.io", "LeaderElection"),
+		"Any kind in coordination.k8s.io should be excluded via wildcard")
+	assert.False(t, IsResourceExcluded("apps", "Deployment"),
+		"Other groups should not be affected")
+}
+
+// Wildcard group and kind excludes everything.
+func TestExclude_WildcardAll(t *testing.T) {
+	teardown, _ := setupExcludeTest(t)
+	defer teardown()
+
+	cfg := makeExcludeConfig("test-namespace", "*", "*")
+	fakeClient := fake.NewSimpleDynamicClient(runtime.NewScheme(), cfg)
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	assert.True(t, IsResourceExcluded("apps", "Deployment"),
+		"Deployment should be excluded via global wildcard")
+	assert.True(t, IsResourceExcluded("", "Pod"),
+		"Core-group Pod should be excluded via global wildcard")
+}
+
+// Core-group (empty apiGroup) specific kind is excluded.
+func TestExclude_CoreGroup(t *testing.T) {
+	teardown, _ := setupExcludeTest(t)
+	defer teardown()
+
+	cfg := makeExcludeConfig("test-namespace", "", "Event")
+	fakeClient := fake.NewSimpleDynamicClient(runtime.NewScheme(), cfg)
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	assert.True(t, IsResourceExcluded("", "Event"),
+		"Core-group Event should be excluded")
+	assert.False(t, IsResourceExcluded("", "Pod"),
+		"Core-group Pod should not be excluded")
+	assert.False(t, IsResourceExcluded("events.k8s.io", "Event"),
+		"Event in different apiGroup should not be excluded")
+}
+
+// Exclude does not affect mergedTransformConfig — default properties still extracted.
+func TestExclude_DoesNotAffectTransformConfig(t *testing.T) {
+	teardown, _ := setupExcludeTest(t)
+	defer teardown()
+
+	cfg := makeExcludeConfig("test-namespace", "coordination.k8s.io", "Lease")
+	fakeClient := fake.NewSimpleDynamicClient(runtime.NewScheme(), cfg)
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	// The exclude rule should not remove the Lease entry from mergedTransformConfig;
+	// exclusion is enforced at the informer layer, not in the transform config.
+	_, found := mergedTransformConfig["Lease.coordination.k8s.io"]
+	assert.False(t, found,
+		"Lease.coordination.k8s.io was not in defaultTransformConfig so should not appear in mergedTransformConfig")
+	// The Pod default config should still be intact.
+	_, podFound := mergedTransformConfig["Pod"]
+	assert.True(t, podFound, "Default Pod config should still be present in mergedTransformConfig")
+}
+
+// Last entry wins: include after exclude for same resource cancels the exclusion.
+func TestExclude_LastEntryWins_IncludeAfterExclude(t *testing.T) {
+	teardown, _ := setupExcludeTest(t)
+	defer teardown()
+
+	collectConditions := true
+	cfg := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					// Rule 1: include Lease (sets collectConditions)
+					map[string]interface{}{
+						"action":             "include",
+						"collectConditions":  collectConditions,
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"coordination.k8s.io"},
+							"kinds":     []interface{}{"Lease"},
+						},
+					},
+					// Rule 2: exclude Lease
+					map[string]interface{}{
+						"action": "exclude",
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"coordination.k8s.io"},
+							"kinds":     []interface{}{"Lease"},
+						},
+					},
+					// Rule 3: include Lease again — last entry wins, should cancel exclude
+					map[string]interface{}{
+						"action":             "include",
+						"collectConditions":  collectConditions,
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"coordination.k8s.io"},
+							"kinds":     []interface{}{"Lease"},
+						},
+					},
+				},
+			},
+		},
+	}
+	fakeClient := fake.NewSimpleDynamicClient(runtime.NewScheme(), cfg)
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	assert.False(t, IsResourceExcluded("coordination.k8s.io", "Lease"),
+		"Last include should cancel the prior exclude — Lease should NOT be excluded")
+}
+
+// Last entry wins: exclude after include for same resource keeps the exclusion.
+func TestExclude_LastEntryWins_ExcludeAfterInclude(t *testing.T) {
+	teardown, _ := setupExcludeTest(t)
+	defer teardown()
+
+	collectConditions := true
+	cfg := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{
+					// Rule 1: include Lease
+					map[string]interface{}{
+						"action":             "include",
+						"collectConditions":  collectConditions,
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"coordination.k8s.io"},
+							"kinds":     []interface{}{"Lease"},
+						},
+					},
+					// Rule 2: exclude Lease — last entry, should win
+					map[string]interface{}{
+						"action": "exclude",
+						"resourceSelector": map[string]interface{}{
+							"apiGroups": []interface{}{"coordination.k8s.io"},
+							"kinds":     []interface{}{"Lease"},
+						},
+					},
+				},
+			},
+		},
+	}
+	fakeClient := fake.NewSimpleDynamicClient(runtime.NewScheme(), cfg)
+	loadAndMergeConfigurableCollectionWithClient(fakeClient)
+
+	assert.True(t, IsResourceExcluded("coordination.k8s.io", "Lease"),
+		"Last exclude should win — Lease should be excluded")
+}
+
+// IsResourceExcluded returns false when no exclude rules loaded (nil map).
+func TestExclude_NilMap(t *testing.T) {
+	excludedResources = nil
+	assert.False(t, IsResourceExcluded("apps", "Deployment"),
+		"Should return false when excludedResources is nil")
+}
+
+// Config reload resets excludedResources — old excludes do not persist.
+func TestExclude_ResetOnReload(t *testing.T) {
+	teardown, _ := setupExcludeTest(t)
+	defer teardown()
+
+	// First load: exclude Lease
+	cfg1 := makeExcludeConfig("test-namespace", "coordination.k8s.io", "Lease")
+	fakeClient1 := fake.NewSimpleDynamicClient(runtime.NewScheme(), cfg1)
+	loadAndMergeConfigurableCollectionWithClient(fakeClient1)
+	assert.True(t, IsResourceExcluded("coordination.k8s.io", "Lease"))
+
+	// Second load: no exclude rules
+	cfg2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "search.open-cluster-management.io/v1alpha1",
+			"kind":       "CollectorConfig",
+			"metadata": map[string]interface{}{
+				"name":      "merged-collector-config",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{
+				"collectionRules": []interface{}{},
+			},
+		},
+	}
+	fakeClient2 := fake.NewSimpleDynamicClient(runtime.NewScheme(), cfg2)
+	loadAndMergeConfigurableCollectionWithClient(fakeClient2)
+	assert.False(t, IsResourceExcluded("coordination.k8s.io", "Lease"),
+		"Previous exclude should be cleared after reload with no exclude rules")
 }


### PR DESCRIPTION
## Summary

Implements `action: exclude` in `CollectorConfig` collection rules (ACM-35522), allowing users to stop the search-collector from indexing specific resource types.

**Companion PR:** stolostron/search-v2-operator#740 (webhook validation + merge protection)

## Changes

**`pkg/transforms/configurableCollection.go`**

- `excludeRules []excludeRule` — ordered slice replacing the old `excludedResources map[string]struct{}` (compound-key map). Each entry is `{apiGroups, kinds, action}` matching the same cartesian wildcard logic as `isResourceMatchingList` in `supportedResources.go`, aligning the exclude implementation with the existing Allow/Deny feature.
- `appendExcludeRule()` — replaces `mergeExcludeRules` + `unmergeExcludeRules`. Both exclude and valid include rules are appended to the list.
- `IsResourceExcluded()` — walks the ordered list; last matching rule determines the outcome (last-match-wins). An ActionInclude entry cancels any prior ActionExclude for the same resource.
- `matchesExcludeRule()` — shared cartesian `(g=="*" || g==group) && (k=="*" || k==kind)` logic.

**Wildcard-vs-specific resolved:**
`exclude "*.*"` + `include "Deployment.apps"` → Deployments are collected, all other resources excluded. This is the primary migration use case for users moving from the AllowedResources ConfigMap feature.

**`pkg/informer/informer.go`**

- `IsResourceExcluded()` gate at all 3 event entry points (list sync, ADDED, MODIFIED).

## Design decisions

- Exclude is enforced at the **informer layer** so resources are stopped before any transform work.
- Integration team protection is handled in the **operator** (merge time), not the collector.
- "Last entry wins" with proper wildcard resolution: a specific include overrides a prior wildcard exclude.
- `matchesExcludeRule` uses the same cartesian logic as `isResourceMatchingList` for consistency with Allow/Deny.

## Known design behavior

**Stale records after adding an exclude rule:** Previously indexed resources remain in the search DB until deleted from the cluster. This is an inherent consequence of informer-layer enforcement.

## Test plan

- `go test ./pkg/transforms/` — 12 exclude tests pass including `TestExclude_WildcardOverriddenBySpecificInclude`
- `go test ./...` — all tests pass, `golangci-lint` 0 issues
- E2E on cluster pending (see Jira ACM-35522 for full test matrix)
