### PR TITLE
ACM-32738 - add additionalColumns to configs wanting them

### DIFF
--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -666,6 +666,12 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 		}
 	}
 
+	// When a specific config has additionalPrinterColumnsPriority set, append the CRD's
+	// printer columns so they are available for priority filtering below.
+	if found && transformConfig.additionalPrinterColumnsPriority != nil {
+		transformConfig.properties = append(transformConfig.properties, additionalColumns...)
+	}
+
 	// Pull in additionalPrinterColumns when globally enabled, gatekeeper constraint,
 	// or when a wildcard config has only additionalPrinterColumnsPriority set.
 	if !found {

--- a/pkg/transforms/common_test.go
+++ b/pkg/transforms/common_test.go
@@ -457,6 +457,40 @@ func TestAdditionalPrinterColumns_SpecificConfig_BothPropertiesAndPrinterColumns
 	assert.Equal(t, "v1", node.Properties["apiversion"], "Default property 'apiversion' should be collected")
 }
 
+func TestAdditionalPrinterColumns_SpecificConfigPriorityOnly_CollectedViaAdditionalColumns(t *testing.T) {
+	// When a specific ResourceConfig has only additionalPrinterColumnsPriority set (no custom
+	// fields), CRD printer columns passed via additionalColumns at runtime should still be
+	// collected. This matches the real flow where mergeCollectPrinterColumns creates a config
+	// with priority set but empty properties.
+	zeroPrio := 0
+	origConfig := mergedTransformConfig
+	mergedTransformConfig = map[string]ResourceConfig{
+		"Fake.test.io": {
+			properties:                       []ExtractProperty{},
+			additionalPrinterColumnsPriority: intPtr(0),
+		},
+	}
+	defer func() { mergedTransformConfig = origConfig }()
+
+	r := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "test.io/v1",
+			"kind":       "Fake",
+			"metadata":   map[string]interface{}{"name": "test", "uid": "uid-1", "creationTimestamp": "2024-01-01T00:00:00Z"},
+			"status":     map[string]interface{}{"phase": "Running"},
+		},
+	}
+
+	// Simulate CRD printer columns passed at runtime by the informer.
+	additionalColumns := []ExtractProperty{
+		{Name: "status", JSONPath: "{.status.phase}", Priority: &zeroPrio},
+	}
+
+	node := GenericResourceBuilder(&r, additionalColumns...).BuildNode()
+	assert.Equal(t, "Running", node.Properties["status"],
+		"Printer column should be collected when specific config has priority set and columns are passed at runtime")
+}
+
 func TestConvertToString(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-32738

### Description of changes
- Follow up to https://github.com/stolostron/search-collector/pull/885, additionalColumns needed to be added to resourceconfigs that were configured to collect certain priority additionalPrinterColumns. Else for ResourceConfigs without properties, we wouldn't parse them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of printer column priorities so configured columns are now included consistently in matching transform settings.
  * Fixed a case where runtime column data could be skipped for specific configurations with priority enabled.

* **Tests**
  * Added coverage for priority-only configurations to ensure printer columns are collected correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->