### PR TITLE
chore: disable Qodo auto-feedback

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,2 +1,2 @@
-[checks]
-enable_auto_checks_feedback = false 
+[config]
+disable_auto_feedback = true


### PR DESCRIPTION
Propagates the change from stolostron/search-v2-operator#765.

Updates `.pr_agent.toml` to use the current Qodo/PR-Agent config key that disables automatic review feedback on PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to disable automatic feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->