### PR TITLE
Increase lint timeout in prow to 10m

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -10,7 +10,7 @@ build:
 lint:
 	GOPATH=$(go env GOPATH)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.9.0
-	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=3m
+	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=10m
 	gosec ./...
 	
 .PHONY: unit-test


### PR DESCRIPTION
### Related Issue
N/A
### Description of changes
- Increase lint timeout in prow to 10m


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the linting time limit to allow checks more time to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->