### PR TITLE
Add userCount for OpenShift Groups

### DIFF
--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -857,6 +857,17 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 						prop.Name, kind, group, r.GetName(), val,
 					)
 				}
+			} else if prop.DataType == DataTypeCount {
+				if arr, ok := val.([]interface{}); ok {
+					node.Properties[prop.Name] = int64(len(arr))
+				} else if val == nil {
+					node.Properties[prop.Name] = int64(0)
+				} else {
+					klog.V(1).Infof(
+						"Unable to count prop [%s] from [%s.%s] Name: [%s], not an array: %T",
+						prop.Name, kind, group, r.GetName(), val,
+					)
+				}
 			} else if prop.DataType == DataTypeBoolean {
 				// DataTypeBoolean: convert to string representation
 				if b, ok := val.(bool); ok {

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -857,14 +857,14 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 						prop.Name, kind, group, r.GetName(), val,
 					)
 				}
-			} else if prop.DataType == DataTypeCount {
-				if arr, ok := val.([]interface{}); ok {
-					node.Properties[prop.Name] = int64(len(arr))
+			} else if prop.DataType == DataTypeSliceLen {
+				if slice, ok := val.([]interface{}); ok {
+					node.Properties[prop.Name] = int64(len(slice))
 				} else if val == nil {
 					node.Properties[prop.Name] = prop.DefaultValue
 				} else {
 					klog.V(1).Infof(
-						"Unable to count prop [%s] from [%s.%s] Name: [%s], not an array: %T",
+						"Unable to get length of prop [%s] from [%s.%s] Name: [%s], not a slice: %T",
 						prop.Name, kind, group, r.GetName(), val,
 					)
 				}

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -861,7 +861,7 @@ func applyDefaultTransformConfig(node Node, r *unstructured.Unstructured, additi
 				if arr, ok := val.([]interface{}); ok {
 					node.Properties[prop.Name] = int64(len(arr))
 				} else if val == nil {
-					node.Properties[prop.Name] = int64(0)
+					node.Properties[prop.Name] = prop.DefaultValue
 				} else {
 					klog.V(1).Infof(
 						"Unable to count prop [%s] from [%s.%s] Name: [%s], not an array: %T",

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -34,7 +34,7 @@ const (
 	DataTypeNumber    DataType = "number"
 	DataTypeMapString DataType = "mapString"
 	DataTypeBoolean   DataType = "boolean"
-	DataTypeCount     DataType = "count"
+	DataTypeSliceLen  DataType = "sliceLen"
 )
 
 // matchLabelKiagnose is the label used to identify kiagnose network-latency checkup ConfigMaps.
@@ -54,8 +54,8 @@ func stringToDataType(s string) DataType {
 		return DataTypeMapString
 	case "boolean":
 		return DataTypeBoolean
-	case "count":
-		return DataTypeCount
+	case "sliceLen":
+		return DataTypeSliceLen
 	default:
 		return DataTypeString
 	}
@@ -236,7 +236,7 @@ var defaultTransformConfig = map[string]ResourceConfig{
 	},
 	"Group.user.openshift.io": {
 		properties: []ExtractProperty{
-			{Name: "userCount", JSONPath: `.users`, DataType: DataTypeCount, DefaultValue: int64(0)},
+			{Name: "userCount", JSONPath: `.users`, DataType: DataTypeSliceLen, DefaultValue: int64(0)},
 		},
 	},
 	"Job.batch": {

--- a/pkg/transforms/genericResourceConfig.go
+++ b/pkg/transforms/genericResourceConfig.go
@@ -34,6 +34,7 @@ const (
 	DataTypeNumber    DataType = "number"
 	DataTypeMapString DataType = "mapString"
 	DataTypeBoolean   DataType = "boolean"
+	DataTypeCount     DataType = "count"
 )
 
 // matchLabelKiagnose is the label used to identify kiagnose network-latency checkup ConfigMaps.
@@ -53,6 +54,8 @@ func stringToDataType(s string) DataType {
 		return DataTypeMapString
 	case "boolean":
 		return DataTypeBoolean
+	case "count":
+		return DataTypeCount
 	default:
 		return DataTypeString
 	}
@@ -229,6 +232,11 @@ var defaultTransformConfig = map[string]ResourceConfig{
 			{Name: "current", JSONPath: `.status.replicas`, DataType: DataTypeNumber},
 			{Name: "ready", JSONPath: `.status.readyReplicas`, DataType: DataTypeNumber},
 			{Name: "desired", JSONPath: `.spec.replicas`, DataType: DataTypeNumber},
+		},
+	},
+	"Group.user.openshift.io": {
+		properties: []ExtractProperty{
+			{Name: "userCount", JSONPath: `.users`, DataType: DataTypeCount, DefaultValue: int64(0)},
 		},
 	},
 	"Job.batch": {

--- a/pkg/transforms/genericResourceConfig_test.go
+++ b/pkg/transforms/genericResourceConfig_test.go
@@ -21,7 +21,7 @@ func TestStringToDataType(t *testing.T) {
 		{"number", "number", DataTypeNumber},
 		{"mapString", "mapString", DataTypeMapString},
 		{"boolean", "boolean", DataTypeBoolean},
-		{"count", "count", DataTypeCount},
+		{"sliceLen", "sliceLen", DataTypeSliceLen},
 		{"Empty String", "", DataTypeString},             // Default
 		{"Unknown Value", "UnknownType", DataTypeString}, // Default
 		{"Invalid Case", "Bytes", DataTypeString},        // Case-sensitive, should default

--- a/pkg/transforms/genericResourceConfig_test.go
+++ b/pkg/transforms/genericResourceConfig_test.go
@@ -21,6 +21,7 @@ func TestStringToDataType(t *testing.T) {
 		{"number", "number", DataTypeNumber},
 		{"mapString", "mapString", DataTypeMapString},
 		{"boolean", "boolean", DataTypeBoolean},
+		{"count", "count", DataTypeCount},
 		{"Empty String", "", DataTypeString},             // Default
 		{"Unknown Value", "UnknownType", DataTypeString}, // Default
 		{"Invalid Case", "Bytes", DataTypeString},        // Case-sensitive, should default

--- a/pkg/transforms/genericResource_test.go
+++ b/pkg/transforms/genericResource_test.go
@@ -1463,3 +1463,69 @@ func TestSubscription_AdditionalColumnsPassThrough(t *testing.T) {
 	assert.Equal(t, "Subscribed", node.Properties["phase"],
 		"additionalColumns must flow through SubscriptionResourceBuilder variadic param")
 }
+
+// ---- Group ------------------------------------------------------------
+
+func newTestGroup(fields map[string]interface{}) *unstructured.Unstructured {
+	obj := map[string]interface{}{
+		"apiVersion": "user.openshift.io/v1",
+		"kind":       "Group",
+		"metadata":   map[string]interface{}{"name": "test-group"},
+	}
+	for k, v := range fields {
+		obj[k] = v
+	}
+
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func TestGroup_UserCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource *unstructured.Unstructured
+		expected int64
+	}{
+		{
+			// Guard against changing the configured JSONPath from `.users` to `.users[*]`.
+			name:     "multiple members",
+			expected: int64(3),
+			resource: newTestGroup(map[string]interface{}{
+				"users": []interface{}{"alice", "bob", "carol"},
+			}),
+		},
+		{
+			name:     "single member",
+			expected: int64(1),
+			resource: newTestGroup(map[string]interface{}{
+				"users": []interface{}{"alice"},
+			}),
+		},
+		{
+			name:     "empty users array",
+			expected: int64(0),
+			resource: newTestGroup(map[string]interface{}{
+				"users": []interface{}{},
+			}),
+		},
+		{
+			name:     "users field absent",
+			expected: int64(0),
+			resource: newTestGroup(map[string]interface{}{}),
+		},
+		{
+			name:     "users is null",
+			expected: int64(0),
+			resource: newTestGroup(map[string]interface{}{
+				"users": nil,
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := GenericResourceBuilder(tt.resource).BuildNode()
+			assert.Equal(t, tt.expected, node.Properties["userCount"],
+				"userCount must equal len(Group.users)")
+		})
+	}
+}


### PR DESCRIPTION
User Story: https://redhat.atlassian.net/browse/ACM-42679
Adds `userCount` for `Group.user.openshift.io` resources by counting entries in `.users`.
- Returns `0` for empty, missing, or null `users`
- Adds unit coverage for the new behavior

Tested with `make test` and verified against a 5.0 test hub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for deriving array lengths with the `sliceLen` data type.
  - OpenShift Group resources now expose `userCount` based on the number of users.
  - Missing, null, or empty user lists are handled appropriately, including configured defaults where applicable.
- **Bug Fixes**
  - Non-array values are no longer stored as slice-length properties and generate a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->